### PR TITLE
Rename 'database' to 'source' for db:clone

### DIFF
--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -36,7 +36,7 @@ module Aptible
                 fail Thor::Error, "Could not find database #{source_handle}"
               end
 
-              op = source.create_operation(type: clone, handle: dest_handle)
+              op = source.create_operation(type: 'clone', handle: dest_handle)
               poll_for_success(op)
               dest = database_from_handle(dest_handle)
               say dest.connection_url


### PR DESCRIPTION
Looks like there were a couple typo's in this function.
