### PR TITLE
Add option to force tty on ssh command

### DIFF
--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -17,6 +17,7 @@ module Aptible
               If specifying an app, invoke via: aptible ssh [--app=APP] COMMAND
             LONGDESC
             option :app
+            option :force_tty, type: :boolean
             def ssh(*args)
               app = ensure_app(options)
               host = app.account.bastion_host
@@ -26,8 +27,9 @@ module Aptible
               ENV['APTIBLE_COMMAND'] = command_from_args(*args)
               ENV['APTIBLE_APP'] = app.handle
 
-              opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \
-                     '-o UserKnownHostsFile=/dev/null'
+              opts = options[:force_tty] ? '-t -t' : ''
+              opts << " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \
+                      '-o UserKnownHostsFile=/dev/null'
               Kernel.exec "ssh #{opts} -p #{port} root@#{host}"
             end
 


### PR DESCRIPTION
Our Bamboo builds were hanging whenever we ran `aptible ssh [command]`, with this warning:

```
Pseudo-terminal will not be allocated because stdin is not a terminal.
```

Adding an option to force TTY fixes this problem.
