### PR TITLE
Specify app via named remotes

### DIFF
--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -8,7 +8,9 @@ module Aptible
         include Helpers::Token
 
         def ensure_app(options = {})
-          handle = options[:app] || ensure_default_handle
+          handle = options[:app] ||
+                   handle_from_remote(options[:remote]) ||
+                   ensure_default_handle
           app = app_from_handle(handle)
           return app if app
           fail Thor::Error, "Could not find app #{handle}"
@@ -29,8 +31,12 @@ module Aptible
         end
 
         def default_handle
+          handle_from_remote(:aptible)
+        end
+
+        def handle_from_remote(remote_name)
           git = Git.open(Dir.pwd)
-          aptible_remote = git.remote(:aptible).url || ''
+          aptible_remote = git.remote(remote_name).url || ''
           aptible_remote[/:(?<name>.+)\.git/, :name]
         rescue
           nil

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -21,6 +21,7 @@ module Aptible
 
             desc 'config:add', 'Add an ENV variable to an app'
             option :app
+            option :remote, aliases: '-r'
             define_method 'config:add' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
@@ -32,12 +33,14 @@ module Aptible
 
             desc 'config:set', 'Alias for config:add'
             option :app
+            option :remote, aliases: '-r'
             define_method 'config:set' do |*args|
               send('config:add', *args)
             end
 
             desc 'config:rm', 'Remove an ENV variable from an app'
             option :app
+            option :remote, aliases: '-r'
             define_method 'config:rm' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
@@ -49,6 +52,7 @@ module Aptible
 
             desc 'config:unset', 'Alias for config:rm'
             option :app
+            option :remote, aliases: '-r'
             define_method 'config:unset' do |*args|
               send('config:add', *args)
             end

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -11,6 +11,7 @@ module Aptible
 
             desc 'config', "Print an app's current configuration"
             option :app
+            option :remote, aliases: '-r'
             def config
               app = ensure_app(options)
               config = app.current_configuration

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -11,6 +11,7 @@ module Aptible
 
             desc 'logs', 'Follows logs from a running app'
             option :app
+            option :remote, aliases: '-r'
             def logs
               app = ensure_app(options)
               host = app.account.bastion_host

--- a/lib/aptible/cli/subcommands/rebuild.rb
+++ b/lib/aptible/cli/subcommands/rebuild.rb
@@ -9,6 +9,7 @@ module Aptible
 
             desc 'rebuild', 'Rebuild an app, and restart its services'
             option :app
+            option :remote, aliases: '-r'
             def rebuild
               app = ensure_app(options)
               operation = app.create_operation(type: 'rebuild')

--- a/lib/aptible/cli/subcommands/restart.rb
+++ b/lib/aptible/cli/subcommands/restart.rb
@@ -9,6 +9,7 @@ module Aptible
 
             desc 'restart', 'Restart all services associated with an app'
             option :app
+            option :remote, aliases: '-r'
             def restart
               app = ensure_app(options)
               operation = app.create_operation(type: 'restart')

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -16,6 +16,7 @@ module Aptible
               If specifying an app, invoke via: aptible ssh [--app=APP] COMMAND
             LONGDESC
             option :app
+            option :remote, aliases: '-r'
             option :force_tty, type: :boolean
             def ssh(*args)
               app = ensure_app(options)


### PR DESCRIPTION
Adds the option of specifying an app via named remotes, rather than the full app handle, like Heroku's `-r` option.  

If interested in merging, I will add the option to the rest of the commands that already support the `--app` option.

As a matter of style, would you prefer to add that option explicitly, like done below, or create a class method along the lines of `app_option` that adds both the app and remote options at once?  This could be defined in the `Helpers::App` module and automatically extended onto the base via the `included` hook.

Also, wasn't sure how to test this.