### PR TITLE
Accept ENV["APTIBLE_REMOTE"] to determine remote name

### DIFF
--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -8,8 +8,9 @@ module Aptible
         include Helpers::Token
 
         def ensure_app(options = {})
+          remote = options[:remote] || ENV['APTIBLE_REMOTE']
           handle = options[:app] ||
-                   handle_from_remote(options[:remote]) ||
+                   handle_from_remote(remote) ||
                    ensure_default_handle
           app = app_from_handle(handle)
           return app if app

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.5.7'
+    VERSION = '0.5.8'
   end
 end


### PR DESCRIPTION
This makes it much easier to manage multiple Aptible environments. For example, one can define:

```
alias staging="APTIBLE_AUTH_ROOT_URL=https://auth.aptible-staging.com \
               APTIBLE_API_ROOT_URL=https://api.aptible-staging.com \
               APTIBLE_REMOTE=staging"
```

Then, run (e.g.):

```
staging aptible ssh
```

And there's no longer a need for complex Bash functions like `aptible-staging`.
