### PR TITLE
Add command for printing out domains

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -11,6 +11,7 @@ require_relative 'helpers/env'
 require_relative 'subcommands/apps'
 require_relative 'subcommands/config'
 require_relative 'subcommands/db'
+require_relative 'subcommands/domains'
 require_relative 'subcommands/logs'
 require_relative 'subcommands/ps'
 require_relative 'subcommands/rebuild'
@@ -26,6 +27,7 @@ module Aptible
       include Subcommands::Apps
       include Subcommands::Config
       include Subcommands::DB
+      include Subcommands::Domains
       include Subcommands::Logs
       include Subcommands::Ps
       include Subcommands::Rebuild

--- a/lib/aptible/cli/subcommands/domains.rb
+++ b/lib/aptible/cli/subcommands/domains.rb
@@ -1,5 +1,4 @@
 require 'shellwords'
-require 'pry'
 
 module Aptible
   module CLI

--- a/lib/aptible/cli/subcommands/domains.rb
+++ b/lib/aptible/cli/subcommands/domains.rb
@@ -1,0 +1,45 @@
+require 'shellwords'
+require 'pry'
+
+module Aptible
+  module CLI
+    module Subcommands
+      module Domains
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::Operation
+            include Helpers::App
+
+            desc 'domains', "Print an app's current virtual domains"
+            option :app
+            option :remote, aliases: '-r'
+            def domains
+              app = ensure_app(options)
+              print_vhosts(app) do |vhost|
+                vhost.virtual_domain
+              end
+            end
+
+            desc 'domains:hostnames', "Print an app's hostnames"
+            option :app
+            option :remote, aliases: '-r'
+            define_method 'domains:hostnames' do
+              app = ensure_app(options)
+              print_vhosts(app) do |vhost|
+                "#{vhost.virtual_domain} -> #{vhost.external_host}"
+              end
+            end
+
+            private
+
+            def print_vhosts(app)
+              (app.vhosts || []).each do |vhost|
+                say yield(vhost)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/domains_spec.rb
+++ b/spec/aptible/cli/subcommands/domains_spec.rb
@@ -1,0 +1,74 @@
+require 'ostruct'
+require 'spec_helper'
+
+class App < OpenStruct
+end
+
+class Service < OpenStruct
+end
+
+class Operation < OpenStruct
+end
+
+class Vhost < OpenStruct
+end
+
+describe Aptible::CLI::Agent do
+  before { subject.stub(:ask) }
+  before { subject.stub(:save_token) }
+  before { subject.stub(:fetch_token) { double 'token' } }
+
+  let(:service) { Service.new(process_type: 'web') }
+  let(:op) { Operation.new(status: 'succeeded') }
+  let(:app) { App.new(handle: 'hello', services: [service]) }
+  let(:apps) { [app] }
+
+  let(:vhost1) { Vhost.new(virtual_domain: 'domain1', external_host: 'host1') }
+  let(:vhost2) { Vhost.new(virtual_domain: 'domain2', external_host: 'host2') }
+
+  describe '#domains' do
+    it 'should print out the hostnames' do
+      allow(service).to receive(:create_operation) { op }
+      allow(subject).to receive(:options) { { app: 'hello' } }
+      allow(Aptible::Api::App).to receive(:all) { apps }
+
+      expect(app).to receive(:vhosts) { [vhost1, vhost2] }
+      expect(subject).to receive(:say).with('domain1')
+      expect(subject).to receive(:say).with('domain2')
+
+      subject.send('domains')
+    end
+
+    it 'should fail if app is non-existent' do
+      allow(service).to receive(:create_operation) { op }
+      allow(Aptible::Api::App).to receive(:all) { apps }
+
+      expect do
+        subject.send('domains')
+      end.to raise_error(Thor::Error)
+    end
+  end
+
+  describe '#domains:hostnames' do
+    it 'should print out the hostnames' do
+      allow(service).to receive(:create_operation) { op }
+      allow(subject).to receive(:options) { { app: 'hello' } }
+      allow(Aptible::Api::App).to receive(:all) { apps }
+
+      expect(app).to receive(:vhosts) { [vhost1, vhost2] }
+      expect(subject).to receive(:say).with('domain1 -> host1')
+      expect(subject).to receive(:say).with('domain2 -> host2')
+
+      subject.send('domains:hostnames')
+    end
+
+    it 'should fail if app is non-existent' do
+      allow(service).to receive(:create_operation) { op }
+      allow(Aptible::Api::App).to receive(:all) { apps }
+
+      expect do
+        subject.send('domains:hostnames')
+      end.to raise_error(Thor::Error)
+    end
+  end
+end


### PR DESCRIPTION
Get the virtual domain from each vhost for an app.

New commands:
aptible domains: Print out the virtual domain for each vhost associated with an app.

aptible domains:hostnames: Print out the mapping of virtual domains to external hosts for each vhost associated with an app.