### PR TITLE
Add `db:list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Commands:
 * Graham Melcher ([@melcher](https://github.com/melcher))
 * Pete Browne ([@petebrowne](https://github.com/petebrowne))
 * Rich Humphrey ([@rdh](https://github.com/rdh))
-
+* Daniel Levenson ([@dleve123](https://github.com/dleve123))
 
 ## Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Commands:
   aptible db:create HANDLE            # Create a new database
   aptible db:dump HANDLE              # Dump a remote database to file
   aptible db:execute HANDLE SQL_FILE  # Executes sql against a database
+  aptible db:list                     # List all databases
   aptible db:tunnel HANDLE            # Create a local tunnel to a database
   aptible help [COMMAND]              # Describe available commands or one specific command
   aptible login                       # Log in to Aptible

--- a/lib/aptible/cli/helpers/account.rb
+++ b/lib/aptible/cli/helpers/account.rb
@@ -7,6 +7,18 @@ module Aptible
       module Account
         include Helpers::Token
 
+        def appropriate_accounts(options)
+          if options[:account]
+            if (account = account_from_handle(options[:account]))
+              [account]
+            else
+              fail Thor::Error, 'Specified account does not exist'
+            end
+          else
+            Aptible::Api::Account.all(token: fetch_token)
+          end
+        end
+
         def ensure_account(options = {})
           if (handle = options[:account])
             account = account_from_handle(handle)

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -10,13 +10,7 @@ module Aptible
             desc 'apps', 'List all applications'
             option :account
             def apps
-              if options[:account]
-                accounts = [account_from_handle(options[:account])]
-              else
-                accounts = Aptible::Api::Account.all(token: fetch_token)
-              end
-
-              accounts.each do |account|
+              appropriate_accounts(options).each do |account|
                 say "=== #{account.handle}"
                 account.apps.each do |app|
                   say app.handle

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -10,6 +10,14 @@ module Aptible
             include Helpers::Token
             include Term::ANSIColor
 
+            desc 'db:list', 'List all databases'
+            option :account
+            define_method 'db:list' do
+              appropriate_accounts(options).each do |account|
+                present_account_databases(account)
+              end
+            end
+
             desc 'db:create HANDLE', 'Create a new database'
             option :type, default: 'postgresql'
             option :size, default: 10
@@ -77,6 +85,23 @@ module Aptible
             end
 
             private
+
+            def appropriate_accounts(options)
+              if options[:account]
+                if (account = account_from_handle(options[:account]))
+                  [account]
+                else
+                  fail Thor::Error, 'Specified account does not exist'
+                end
+              else
+                Aptible::Api::Account.all(token: fetch_token)
+              end
+            end
+
+            def present_account_databases(account)
+              say "=== #{account.handle}"
+              account.databases.each { |db| say db.handle }
+            end
 
             def establish_connection(database, local_port)
               ENV['ACCESS_TOKEN'] = fetch_token

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -86,18 +86,6 @@ module Aptible
 
             private
 
-            def appropriate_accounts(options)
-              if options[:account]
-                if (account = account_from_handle(options[:account]))
-                  [account]
-                else
-                  fail Thor::Error, 'Specified account does not exist'
-                end
-              else
-                Aptible::Api::Account.all(token: fetch_token)
-              end
-            end
-
             def present_account_databases(account)
               say "=== #{account.handle}"
               account.databases.each { |db| say db.handle }

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 class Database < OpenStruct
 end
 
+class Account < OpenStruct
+end
+
 describe Aptible::CLI::Agent do
   before { subject.stub(:ask) }
   before { subject.stub(:save_token) }
@@ -38,5 +41,88 @@ describe Aptible::CLI::Agent do
       expect(subject).to receive(:say).exactly(6).times
       subject.send('db:tunnel', 'foobar')
     end
+  end
+
+  describe '#db:list' do
+    context 'when no account is specified' do
+      it 'prints out the grouped database handles for all accounts' do
+        setup_prod_and_staging_accounts
+        allow(subject).to receive(:say)
+
+        subject.send('db:list')
+
+        expect(subject).to have_received(:say).with('=== staging')
+        expect(subject).to have_received(:say).with('staging-redis-db')
+        expect(subject).to have_received(:say).with('staging-postgres-db')
+
+        expect(subject).to have_received(:say).with('=== production')
+        expect(subject).to have_received(:say).with('prod-elsearch-db')
+        expect(subject).to have_received(:say).with('prod-postgres-db')
+      end
+    end
+
+    context 'when a valid account is specified' do
+      it 'prints out the database handles for the account' do
+        setup_prod_and_staging_accounts
+        allow(subject).to receive(:say)
+
+        subject.options = { account: 'staging' }
+        subject.send('db:list')
+
+        expect(subject).to have_received(:say).with('=== staging')
+        expect(subject).to have_received(:say).with('staging-redis-db')
+        expect(subject).to have_received(:say).with('staging-postgres-db')
+
+        expect(subject).to_not have_received(:say).with('=== production')
+        expect(subject).to_not have_received(:say).with('prod-elsearch-db')
+        expect(subject).to_not have_received(:say).with('prod-postgres-db')
+      end
+    end
+
+    context 'when an invalid account is specified' do
+      it 'prints out an error' do
+        setup_prod_and_staging_accounts
+        allow(subject).to receive(:say)
+
+        subject.options = { account: 'foo' }
+        expect { subject.send('db:list') }.to raise_error(
+          'Specified account does not exist'
+        )
+      end
+    end
+  end
+
+  def setup_prod_and_staging_accounts
+    staging_redis = Database.new(handle: 'staging-redis-db')
+    staging_postgres = Database.new(handle: 'staging-postgres-db')
+    prod_elsearch = Database.new(handle: 'prod-elsearch-db')
+    prod_postgres = Database.new(handle: 'prod-postgres-db')
+
+    stub_local_token_with('the-token')
+    setup_new_accounts_with_dbs(
+      token: 'the-token',
+      account_db_mapping: {
+        'staging' => [staging_redis, staging_postgres],
+        'production' => [prod_elsearch, prod_postgres]
+      }
+    )
+  end
+
+  def setup_new_accounts_with_dbs(options)
+    token = options.fetch(:token)
+    account_db_mapping = options.fetch(:account_db_mapping)
+
+    accounts_with_dbs = []
+    account_db_mapping.each do |account_handle, dbs|
+      account = Account.new(handle: account_handle, databases: dbs)
+      accounts_with_dbs << account
+    end
+
+    allow(Aptible::Api::Account).to receive(:all).with(token: token)
+      .and_return(accounts_with_dbs)
+  end
+
+  def stub_local_token_with(token)
+    allow(subject).to receive(:fetch_token).and_return(token)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/aptible/aptible-cli/issues/45

To avoid making too many changes, I named the command `db:list` to fit with the already numerous `db:` commands. More than happy to change the name though.

Also improves the developer UI with the `aptible apps` command by leveraging some of the `db:list` implementation.

Happy holidays! :christmas_tree: