### PR TITLE
Allow attaching to logs for some app operations

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -32,6 +32,11 @@ module Aptible
       include Subcommands::Restart
       include Subcommands::SSH
 
+      # Forward return codes on failures.
+      def self.exit_on_failure?
+        true
+      end
+
       desc 'version', 'Print Aptible CLI version'
       def version
         puts "aptible-cli v#{Aptible::CLI::VERSION}"

--- a/lib/aptible/cli/helpers/operation.rb
+++ b/lib/aptible/cli/helpers/operation.rb
@@ -30,7 +30,11 @@ module Aptible
 
           opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \
                  '-o UserKnownHostsFile=/dev/null -o LogLevel=quiet'
-          Kernel.exec "ssh #{opts} -p #{port} root@#{host}"
+          result = Kernel.system "ssh #{opts} -p #{port} root@#{host}"
+          # If Dumptruck is down, fall back to polling for success. If the
+          # operation failed, poll_for_success will immediately fall through to
+          # the error message.
+          poll_for_success(operation) unless result
         end
       end
     end

--- a/lib/aptible/cli/helpers/operation.rb
+++ b/lib/aptible/cli/helpers/operation.rb
@@ -19,6 +19,19 @@ module Aptible
             operation.get
           end
         end
+
+        def attach_to_operation_logs(operation)
+          host = operation.resource.account.bastion_host
+          port = operation.resource.account.dumptruck_port
+
+          set_env('ACCESS_TOKEN', fetch_token)
+          set_env('APTIBLE_OPERATION', operation.id.to_s)
+          set_env('APTIBLE_CLI_COMMAND', 'oplog')
+
+          opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \
+                 '-o UserKnownHostsFile=/dev/null -o LogLevel=quiet'
+          Kernel.exec "ssh #{opts} -p #{port} root@#{host}"
+        end
       end
     end
   end

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -45,8 +45,7 @@ module Aptible
               app = ensure_app(options)
               service = app.services.find { |s| s.process_type == type }
               op = service.create_operation(type: 'scale', container_count: num)
-              poll_for_success(op)
-              say "Scaled #{app.handle} to #{num} instances."
+              attach_to_operation_logs(op)
             end
 
             option :app

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -28,7 +28,7 @@ module Aptible
               env = Hash[args.map { |arg| arg.split('=', 2) }]
               operation = app.create_operation(type: 'configure', env: env)
               puts 'Updating configuration and restarting app...'
-              poll_for_success(operation)
+              attach_to_operation_logs(operation)
             end
 
             desc 'config:set', 'Alias for config:add'
@@ -47,7 +47,7 @@ module Aptible
               env = Hash[args.map { |arg| [arg, ''] }]
               operation = app.create_operation(type: 'configure', env: env)
               puts 'Updating configuration and restarting app...'
-              poll_for_success(operation)
+              attach_to_operation_logs(operation)
             end
 
             desc 'config:unset', 'Alias for config:rm'

--- a/lib/aptible/cli/subcommands/rebuild.rb
+++ b/lib/aptible/cli/subcommands/rebuild.rb
@@ -14,7 +14,7 @@ module Aptible
               app = ensure_app(options)
               operation = app.create_operation(type: 'rebuild')
               puts 'Rebuilding app...'
-              poll_for_success(operation)
+              attach_to_operation_logs(operation)
             end
           end
         end

--- a/lib/aptible/cli/subcommands/restart.rb
+++ b/lib/aptible/cli/subcommands/restart.rb
@@ -14,7 +14,7 @@ module Aptible
               app = ensure_app(options)
               operation = app.create_operation(type: 'restart')
               puts 'Restarting app...'
-              poll_for_success(operation)
+              attach_to_operation_logs(operation)
             end
           end
         end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -10,21 +10,29 @@ end
 class Operation < OpenStruct
 end
 
+class Account < OpenStruct
+end
+
 describe Aptible::CLI::Agent do
   before { subject.stub(:ask) }
   before { subject.stub(:save_token) }
   before { subject.stub(:fetch_token) { double 'token' } }
+  before { subject.stub(:attach_to_operation_logs) }
 
   let(:service) { Service.new(process_type: 'web') }
   let(:op) { Operation.new(status: 'succeeded') }
-  let(:apps) { [App.new(handle: 'hello', services: [service])] }
+  let(:account) { Account.new(bastion_host: 'localhost', dumptruck_port: 1234) }
+  let(:apps) do
+    [App.new(handle: 'hello', services: [service], account: account)]
+  end
 
   describe '#apps:scale' do
     it 'should pass given correct parameters' do
       allow(service).to receive(:create_operation) { op }
       allow(subject).to receive(:options) { { app: 'hello' } }
-
+      allow(op).to receive(:resource) { apps.first }
       allow(Aptible::Api::App).to receive(:all) { apps }
+
       subject.send('apps:scale', 'web', 3)
     end
 
@@ -40,8 +48,8 @@ describe Aptible::CLI::Agent do
     it 'should fail if number is not a valid number' do
       allow(service).to receive(:create_operation) { op }
       allow(subject).to receive(:options) { { app: 'hello' } }
-
       allow(Aptible::Api::App).to receive(:all) { apps }
+
       expect do
         subject.send('apps:scale', 'web', 'potato')
       end.to raise_error(ArgumentError)


### PR DESCRIPTION
SSH-ing into the internal dumptruck service will allow us to forward stdout from operations like restarts, rebuilds, config changes, and service scales.