### PR TITLE
Get all pages of dbs

### DIFF
--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -105,7 +105,14 @@ module Aptible
             end
 
             def database_from_handle(handle, options = { postgres_only: false })
-              all = Aptible::Api::Database.all(token: fetch_token)
+              all = []
+              page = 1
+              loop do
+                dbs = Aptible::Api::Database.all(token: fetch_token, page: page)
+                break if dbs.count == 0
+                page += 1
+                all << dbs
+              end
               database = all.find { |a|  a.handle == handle }
 
               unless database


### PR DESCRIPTION
Closes https://github.com/aptible/aptible-cli/issues/136
Currently, only the first 40 (page size default) are retrieved. More detail in the issue.

@fancyremarker, I couldn't get my local aptible-cli repo to install and run locally. I'd like to verify and test the fix on my local db. Currently, the specs return accounts with populated databases, I need to write a spec with the setup to hit the loop I set up.