### PR TITLE
Increase reverse-compatibility of `--environment` changes

### DIFF
--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -10,12 +10,13 @@ module Aptible
 
         class HandleFromGitRemote
           PATTERN = %r{
-  :((?<environment_handle>[0-9a-z\-_\.]+?)/)?(?<app_handle>[0-9a-z\-_\.]+)\.git
-  \z
-}x
+            :((?<environment_handle>[0-9a-z\-_\.]+?)/)?
+            (?<app_handle>[0-9a-z\-_\.]+)\.git
+            \z
+          }x
 
           def self.parse(url)
-            PATTERN.match(url)
+            PATTERN.match(url) || {}
           end
         end
 
@@ -32,46 +33,48 @@ module Aptible
         end
 
         def ensure_app(options = {})
-          remote = options[:remote] || ENV['APTIBLE_REMOTE']
-          handle = options[:app]
-          if handle
-            environment = ensure_environment(options)
+          remote = options[:remote] || ENV['APTIBLE_REMOTE'] || 'aptible'
+          app_handle = options[:app] || handles_from_remote(remote)[:app_handle]
+          environment_handle = options[:environment] ||
+                               handles_from_remote(remote)[:environment_handle]
+
+          unless app_handle
+            fail Thor::Error, <<-ERR.gsub(/\s+/, ' ').strip
+              Could not find app in current working directory, please specify
+              with --app
+            ERR
+          end
+
+          environment = environment_from_handle(environment_handle)
+          if environment_handle && !environment
+            fail Thor::Error, "Could not find environment #{environment_handle}"
+          end
+          apps = apps_from_handle(app_handle, environment)
+          case apps.count
+          when 1
+            return apps.first
+          when 0
+            fail Thor::Error, "Could not find app #{app_handle}"
           else
-            handles = handle_from_remote(remote) || ensure_default_handle
-            handle = handles[:app_handle]
-            env_handle = handles[:environment_handle] || options[:environment]
-            environment = ensure_environment(environment: env_handle)
-          end
-
-          app = app_from_handle(handle, environment)
-          return app if app
-          fail Thor::Error, "Could not find app #{handle}"
-        end
-
-        def app_from_handle(handle, environment)
-          environment.apps.find do |a|
-            a.handle == handle
+            fail Thor::Error, 'Multiple apps exist, please specify environment'
           end
         end
 
-        def ensure_default_handle
-          return default_handle if default_handle
-          fail Thor::Error, <<-ERR.gsub(/\s+/, ' ').strip
-            Could not find app in current working directory, please specify
-            with --app
-          ERR
+        def apps_from_handle(handle, environment)
+          if environment
+            apps = environment.apps
+          else
+            apps = Aptible::Api::App.all(token: fetch_token)
+          end
+          apps.select { |a| a.handle == handle }
         end
 
-        def default_handle
-          handle_from_remote(:aptible)
-        end
-
-        def handle_from_remote(remote_name)
+        def handles_from_remote(remote_name)
           git = Git.open(Dir.pwd)
           aptible_remote = git.remote(remote_name).url || ''
           HandleFromGitRemote.parse(aptible_remote)
         rescue
-          nil
+          {}
         end
       end
     end

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -19,6 +19,18 @@ module Aptible
           end
         end
 
+        def self.included(base)
+          base.extend ClassMethods
+        end
+
+        module ClassMethods
+          def app_options
+            option :app
+            option :environment
+            option :remote, aliases: '-r'
+          end
+        end
+
         def ensure_app(options = {})
           remote = options[:remote] || ENV['APTIBLE_REMOTE']
           handle = options[:app]

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -30,6 +30,7 @@ module Aptible
         end
 
         def environment_from_handle(handle)
+          return nil unless handle
           Aptible::Api::Account.all(token: fetch_token).find do |a|
             a.handle == handle
           end

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -4,6 +4,7 @@ module Aptible
       module Apps
         def self.included(thor)
           thor.class_eval do
+            include Helpers::App
             include Helpers::Environment
             include Helpers::Token
 
@@ -33,8 +34,7 @@ module Aptible
             end
 
             desc 'apps:scale TYPE NUMBER', 'Scale app to NUMBER of instances'
-            option :app
-            option :environment
+            app_options
             define_method 'apps:scale' do |type, n|
               num = Integer(n)
               app = ensure_app(options)
@@ -43,9 +43,8 @@ module Aptible
               attach_to_operation_logs(op)
             end
 
-            option :app
-            option :environment
             desc 'apps:deprovision', 'Deprovision an app'
+            app_options
             define_method 'apps:deprovision' do
               app = ensure_app(options)
               say "Deprovisioning #{app.handle}..."

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -11,6 +11,7 @@ module Aptible
 
             desc 'config', "Print an app's current configuration"
             option :app
+            option :environment
             option :remote, aliases: '-r'
             def config
               app = ensure_app(options)
@@ -21,6 +22,7 @@ module Aptible
 
             desc 'config:add', 'Add an ENV variable to an app'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             define_method 'config:add' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
@@ -33,6 +35,7 @@ module Aptible
 
             desc 'config:set', 'Alias for config:add'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             define_method 'config:set' do |*args|
               send('config:add', *args)
@@ -40,6 +43,7 @@ module Aptible
 
             desc 'config:rm', 'Remove an ENV variable from an app'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             define_method 'config:rm' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
@@ -52,6 +56,7 @@ module Aptible
 
             desc 'config:unset', 'Alias for config:rm'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             define_method 'config:unset' do |*args|
               send('config:add', *args)

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -10,9 +10,7 @@ module Aptible
             include Helpers::App
 
             desc 'config', "Print an app's current configuration"
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             def config
               app = ensure_app(options)
               config = app.current_configuration
@@ -21,9 +19,7 @@ module Aptible
             end
 
             desc 'config:add', 'Add an ENV variable to an app'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             define_method 'config:add' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
@@ -34,17 +30,13 @@ module Aptible
             end
 
             desc 'config:set', 'Alias for config:add'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             define_method 'config:set' do |*args|
               send('config:add', *args)
             end
 
             desc 'config:rm', 'Remove an ENV variable from an app'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             define_method 'config:rm' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
@@ -55,9 +47,7 @@ module Aptible
             end
 
             desc 'config:unset', 'Alias for config:rm'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             define_method 'config:unset' do |*args|
               send('config:add', *args)
             end

--- a/lib/aptible/cli/subcommands/domains.rb
+++ b/lib/aptible/cli/subcommands/domains.rb
@@ -10,10 +10,8 @@ module Aptible
             include Helpers::App
 
             desc 'domains', "Print an app's current virtual domains"
-            option :app
-            option :environment
+            app_options
             option :verbose, aliases: '-v'
-            option :remote, aliases: '-r'
             def domains
               app = ensure_app(options)
               print_vhosts(app) do |vhost|

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -10,9 +10,7 @@ module Aptible
             include Helpers::App
 
             desc 'logs', 'Follows logs from a running app'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             def logs
               app = ensure_app(options)
 

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -11,6 +11,7 @@ module Aptible
 
             desc 'logs', 'Follows logs from a running app'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             def logs
               app = ensure_app(options)

--- a/lib/aptible/cli/subcommands/ps.rb
+++ b/lib/aptible/cli/subcommands/ps.rb
@@ -12,6 +12,7 @@ module Aptible
 
             desc 'ps', 'Display running processes for an app'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             def ps
               app = ensure_app(options)

--- a/lib/aptible/cli/subcommands/ps.rb
+++ b/lib/aptible/cli/subcommands/ps.rb
@@ -11,9 +11,7 @@ module Aptible
             include Helpers::Env
 
             desc 'ps', 'Display running processes for an app'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             def ps
               app = ensure_app(options)
 

--- a/lib/aptible/cli/subcommands/rebuild.rb
+++ b/lib/aptible/cli/subcommands/rebuild.rb
@@ -9,6 +9,7 @@ module Aptible
 
             desc 'rebuild', 'Rebuild an app, and restart its services'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             def rebuild
               app = ensure_app(options)

--- a/lib/aptible/cli/subcommands/rebuild.rb
+++ b/lib/aptible/cli/subcommands/rebuild.rb
@@ -8,9 +8,7 @@ module Aptible
             include Helpers::App
 
             desc 'rebuild', 'Rebuild an app, and restart its services'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             def rebuild
               app = ensure_app(options)
               operation = app.create_operation(type: 'rebuild')

--- a/lib/aptible/cli/subcommands/restart.rb
+++ b/lib/aptible/cli/subcommands/restart.rb
@@ -9,6 +9,7 @@ module Aptible
 
             desc 'restart', 'Restart all services associated with an app'
             option :app
+            option :environment
             option :remote, aliases: '-r'
             def restart
               app = ensure_app(options)

--- a/lib/aptible/cli/subcommands/restart.rb
+++ b/lib/aptible/cli/subcommands/restart.rb
@@ -8,9 +8,7 @@ module Aptible
             include Helpers::App
 
             desc 'restart', 'Restart all services associated with an app'
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             def restart
               app = ensure_app(options)
               operation = app.create_operation(type: 'restart')

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -15,9 +15,7 @@ module Aptible
 
               If specifying an app, invoke via: aptible ssh [--app=APP] COMMAND
             LONGDESC
-            option :app
-            option :environment
-            option :remote, aliases: '-r'
+            app_options
             option :force_tty, type: :boolean
             def ssh(*args)
               app = ensure_app(options)

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -16,6 +16,7 @@ module Aptible
               If specifying an app, invoke via: aptible ssh [--app=APP] COMMAND
             LONGDESC
             option :app
+            option :environment
             option :remote, aliases: '-r'
             option :force_tty, type: :boolean
             def ssh(*args)

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -35,8 +35,7 @@ describe Aptible::CLI::Agent do
       allow(service).to receive(:create_operation) { op }
       allow(subject).to receive(:options) { { app: 'hello' } }
       allow(op).to receive(:resource) { apps.first }
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
-      allow(account).to receive(:apps) { apps }
+      allow(Aptible::Api::App).to receive(:all) { apps }
 
       subject.send('apps:scale', 'web', 3)
     end

--- a/spec/aptible/cli/subcommands/domains_spec.rb
+++ b/spec/aptible/cli/subcommands/domains_spec.rb
@@ -35,8 +35,7 @@ describe Aptible::CLI::Agent do
     it 'should print out the hostnames' do
       allow(service).to receive(:create_operation) { op }
       allow(subject).to receive(:options) { { app: 'hello' } }
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
-      allow(account).to receive(:apps) { apps }
+      allow(Aptible::Api::App).to receive(:all) { apps }
 
       expect(app).to receive(:vhosts) { [vhost1, vhost2] }
       expect(subject).to receive(:say).with('domain1')
@@ -68,8 +67,7 @@ describe Aptible::CLI::Agent do
     it 'should print hostnames if -v is passed' do
       allow(service).to receive(:create_operation) { op }
       allow(subject).to receive(:options) { { verbose: true, app: 'hello' } }
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
-      allow(account).to receive(:apps) { apps }
+      allow(Aptible::Api::App).to receive(:all) { apps }
 
       expect(app).to receive(:vhosts) { [vhost1, vhost2] }
       expect(subject).to receive(:say).with('domain1 -> host1')


### PR DESCRIPTION
* Add `--environment` as option to all methods that accept `--app` as an option (and refactor into `app_options`)
* Infer app without requiring `--environment` where possible (this will allow customers to continue using their old-format Git remote URLs)