### PR TITLE
Ssh data transport

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -8,6 +8,7 @@ require_relative 'helpers/environment'
 require_relative 'helpers/app'
 require_relative 'helpers/database'
 require_relative 'helpers/env'
+require_relative 'helpers/socat'
 
 require_relative 'subcommands/apps'
 require_relative 'subcommands/config'

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -57,7 +57,7 @@ module Aptible
           # TODO: Should pass the DB ID...
           env = {
             'ACCESS_TOKEN' => fetch_token,
-            'APTIBLE_DATABASE' => database.handle,
+            'APTIBLE_DATABASE' => database.href,
             'TUNNEL_PORT' => '-1'  # Request no port forwarding
           }
           command = ['ssh', '-q'] + ssh_args(database)

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -44,18 +44,6 @@ module Aptible
           say ''
         end
 
-        def establish_connection(database, local_port)
-          ENV['ACCESS_TOKEN'] = fetch_token
-          ENV['APTIBLE_DATABASE'] = database.handle
-
-          remote_port = claim_remote_port(database)
-          ENV['TUNNEL_PORT'] = remote_port
-
-          tunnel_args = "-L #{local_port}:localhost:#{remote_port}"
-          command = "ssh #{tunnel_args} #{common_ssh_args(database)}"
-          Kernel.exec(command)
-        end
-
         def clone_database(source, dest_handle)
           op = source.create_operation(type: 'clone', handle: dest_handle)
           poll_for_success(op)
@@ -63,35 +51,32 @@ module Aptible
           databases_from_handle(dest_handle, source.account).first
         end
 
-        def dump_database(database)
-          execute_local_tunnel(database) do |url|
-            filename = "#{database.handle}.dump"
-            say "Dumping to #{filename}"
-            `pg_dump #{url} > #{filename}`
+        # Creates a local tunnel and yields the port and server thread
+
+        def with_local_tunnel(database, port = 0)
+          # TODO: Should pass the DB ID...
+          env = {
+            'ACCESS_TOKEN' => fetch_token,
+            'APTIBLE_DATABASE' => database.handle,
+            'TUNNEL_PORT' => '-1'  # Request no port forwarding
+          }
+          command = ['ssh', '-q'] + ssh_args(database)
+          Helpers::Socat.new(env, command).tap do |socat_helper|
+            socat_helper.start(port)
+            yield socat_helper
+            socat_helper.stop
           end
         end
 
-        # Creates a local tunnel and yields the url to it
-        def execute_local_tunnel(database)
-          local_port = random_local_port
-          pid = fork { establish_connection(database, local_port) }
+        # Creates a local PG tunnel and yields the url to it
 
-          # TODO: Better test for connection readiness
-          sleep 10
-
-          auth = "aptible:#{database.passphrase}"
-          host = "localhost:#{local_port}"
-          yield "postgresql://#{auth}@#{host}/db"
-        ensure
-          Process.kill('HUP', pid) if pid
-        end
-
-        def random_local_port
-          # Allocate a dummy server to discover an available port
-          dummy = TCPServer.new('127.0.0.1', 0)
-          port = dummy.addr[1]
-          dummy.close
-          port
+        def with_postgres_tunnel(database)
+          # TODO: Should check that the DB is PG?
+          with_local_tunnel(database) do |socat_helper|
+            auth = "aptible:#{database.passphrase}"
+            host = "localhost:#{socat_helper.port}"
+            yield "postgresql://#{auth}@#{host}/db"
+          end
         end
 
         def local_url(database, local_port)
@@ -102,20 +87,16 @@ module Aptible
           "127.0.0.1:#{local_port}#{uri.path}"
         end
 
-        def claim_remote_port(database)
-          ENV['ACCESS_TOKEN'] = fetch_token
-
-          `ssh #{common_ssh_args(database)} 2>/dev/null`.chomp
-        end
-
-        def common_ssh_args(database)
+        def ssh_args(database)
           host = database.account.bastion_host
           port = database.account.bastion_port
 
-          opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \
-                 '-o UserKnownHostsFile=/dev/null'
-          connection_args = "-p #{port} root@#{host}"
-          "#{opts} #{connection_args}"
+          ['-o', 'SendEnv=APTIBLE_DATABASE',
+           '-o', 'SendEnv=TUNNEL_PORT',
+           '-o', 'SendEnv=ACCESS_TOKEN',
+           '-o', 'StrictHostKeyChecking=no',
+           '-o', 'UserKnownHostsFile=/dev/null',
+           '-p', port.to_s, "root@#{host}"]
         end
       end
     end

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -71,7 +71,10 @@ module Aptible
         # Creates a local PG tunnel and yields the url to it
 
         def with_postgres_tunnel(database)
-          # TODO: Should check that the DB is PG?
+          if database.type != 'postgresql'
+            fail Thor::Error, 'This command only works for PostgreSQL'
+          end
+
           with_local_tunnel(database) do |socat_helper|
             auth = "aptible:#{database.passphrase}"
             host = "localhost:#{socat_helper.port}"

--- a/lib/aptible/cli/helpers/socat.rb
+++ b/lib/aptible/cli/helpers/socat.rb
@@ -1,0 +1,155 @@
+require 'socket'
+require 'open3'
+
+module Aptible
+  module CLI
+    module Helpers
+      class Socat
+        BUFFER_SIZE = 4096
+        SELECT_TIMEOUT = 1
+        # TODO: Benchmark peformance against old.
+
+        def initialize(env, command, log_fd = $stderr)
+          @env = env
+          @command = command
+          @log_fd = log_fd
+        end
+
+        def start(port = 0)
+          # TODO: Consider not allowing re-starting
+          q = Queue.new
+          @thread =  Thread.new do
+            begin
+              run_socat_loop(@env, @command, port, q)
+            # rubocop:disable Lint/RescueException
+            rescue Exception => e
+              @log_fd.puts "Socat thread crashed!: #{e.message}"
+              @log_fd.puts e.backtrace
+              raise
+            end
+          end
+          @port = q.deq
+        end
+
+        def wait
+          @thread.join
+        end
+
+        def stop
+          @stop_requested = true
+          wait
+        end
+
+        def port
+          fail 'You must call #start before calling #port!' if @port.nil?
+          @port
+        end
+
+        private
+
+        def run_socat_loop(env, command, port = 0, signal_q = nil)
+          @stop_requested = false
+
+          buffer = ''
+          fd_map = {}
+
+          serv = TCPServer.new(port)
+
+          signal_q.enq(serv.addr[1]) unless signal_q.nil?
+
+          loop do
+            break if @stop_requested
+
+            # TODO: Non blocking writes.
+            # We should check that writers are ready to avoid blocking
+            # the entire event loop on an unavailable writer. This adds
+            # a lot of complexity because we must handle cases where a
+            # writer is ready, but not for all the data we read (i.e. we'd
+            # need to buffer in here). For now, we're making blocking
+            # writes.
+
+            begin
+              for_read, _, _ = IO.select(fd_map.keys + [serv], [], [],
+                                         SELECT_TIMEOUT)
+            rescue Interrupt
+              # Probably CTRL+C or a signal. Expect another thread will set
+              # @stop_requested
+              next
+            rescue IOError
+              # Oops, we have a closed stream somewhere: prune our streams.
+              fd_map.keys.each do |fd|
+                close_read_fd(fd_map, fd) if fd.closed?
+              end
+              next
+            end
+
+            # If we timed out, don't try reading anything!
+            next if for_read.nil?
+
+            for_read.each do |io|
+              if io == serv
+                sock = serv.accept_nonblock
+                stdin, stdout, stderr, _ = Open3.popen3(env, *command)
+
+                fd_map.merge!(
+                  sock => stdin,
+                  stdout => sock,
+                  stderr => @log_fd
+                )
+                next
+              end
+
+              dest_fd = fd_map[io]
+              fail "Unexpected fd was ready: #{io}" if dest_fd.nil?
+
+              begin
+                io.read_nonblock(BUFFER_SIZE, buffer)
+              rescue IO::WaitReadable
+                retry
+              rescue EOFError
+                # Oops, the input fd is closed. Stop reading from it, and
+                # close the output end (unless it's already closed!).
+                close_read_fd(fd_map, io)
+              else
+                begin
+                  dest_fd.write(buffer)
+                  dest_fd.flush
+                rescue IOError
+                  # Oops, the output fd was closed. Close the input end if not
+                  # already done.
+                  fd_map.delete(io)
+                  safe_close_fd(io)
+                end
+              end
+            end
+          end
+
+          # Close all FDs when closing. Expect that the programs we started
+          # will stop once stdin is closed.
+          (fd_map.keys + [serv]).each do |fd|
+            close_read_fd(fd_map, fd)
+          end
+        end
+
+        def close_read_fd(fd_map, fd)
+          dest_fd = fd_map[fd]
+          fd_map.delete(fd)
+
+          # Close the FD, notify the other end that there won't be any more
+          # traffic coming in.
+          safe_close_fd(fd)
+          safe_close_fd(dest_fd) unless dest_fd.nil? || dest_fd == @log_fd
+        end
+
+        def safe_close_fd(fd)
+          fd.close
+        # rubocop:disable Lint/HandleExceptions
+        rescue IOError
+          # Already closed. We don't care.
+          # TODO: Check actual errno?
+        end
+        # rubocop:enable Lint/HandleExceptions
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -50,7 +50,6 @@ module Aptible
             desc 'db:dump HANDLE', 'Dump a remote database to file'
             option :environment
             define_method 'db:dump' do |handle|
-              # TODO: This no longer restricts to PG dbs
               database = ensure_database(options.merge(db: handle))
               with_postgres_tunnel(database) do |url|
                 filename = "#{handle}.dump"

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -23,7 +23,7 @@ module Aptible
               port = app.account.dumptruck_port
 
               ENV['ACCESS_TOKEN'] = fetch_token
-              ENV['APTIBLE_APP'] = app.handle
+              ENV['APTIBLE_APP'] = app.href
               ENV['APTIBLE_CLI_COMMAND'] = 'logs'
 
               opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \

--- a/lib/aptible/cli/subcommands/ps.rb
+++ b/lib/aptible/cli/subcommands/ps.rb
@@ -19,7 +19,7 @@ module Aptible
               port = app.account.dumptruck_port
 
               set_env('ACCESS_TOKEN', fetch_token)
-              set_env('APTIBLE_APP', app.handle)
+              set_env('APTIBLE_APP', app.href)
               set_env('APTIBLE_CLI_COMMAND', 'ps')
 
               opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -24,7 +24,7 @@ module Aptible
 
               ENV['ACCESS_TOKEN'] = fetch_token
               ENV['APTIBLE_COMMAND'] = command_from_args(*args)
-              ENV['APTIBLE_APP'] = app.handle
+              ENV['APTIBLE_APP'] = app.href
 
               opts = options[:force_tty] ? '-t -t' : ''
               opts << " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \

--- a/spec/aptible/cli/helpers/socat_spec.rb
+++ b/spec/aptible/cli/helpers/socat_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+require 'timeout'
+
+describe Aptible::CLI::Helpers::Socat do
+  context 'without connections' do
+    it 'should start and stop in a timely fashion' do
+      socat = described_class.new({}, [])
+      Timeout.timeout(5) do
+        socat.start
+        socat.stop
+      end
+    end
+
+    it 'should fail if #port is called before #start' do
+      socat = described_class.new({}, [])
+      expect { socat.port }.to raise_error(/You must call #start/)
+    end
+  end
+
+  context 'cleanup' do
+    it 'should close all connections when exiting' do
+      socat =  described_class.new({}, ['bash', '-c', 'echo "$$" && cat'])
+      socat.start
+
+      sock = Socket.tcp('127.0.0.1', socat.port)
+      bash_pid = sock.recv(10).to_i
+
+      `ps -p #{bash_pid}`.should include('bash')
+
+      socat.stop
+
+      # Test what we stopped listening for new connections
+      expect { Socket.tcp('127.0.0.1', socat.port) }
+        .to raise_error Errno::ECONNREFUSED
+
+      # Test that bash exits when we close stdin
+      Timeout.timeout(2) do
+        sleep 0.1 while `ps -p #{bash_pid}`.include? 'bash'
+      end
+      `ps -p #{bash_pid}`.should_not include('bash')
+
+      # Note: we can't reasonably test that the socket is closed, because that
+      # takes a while
+    end
+  end
+
+  context 'with socat' do
+    let!(:socat) { described_class.new(socat_env, socat_cmd) }
+    let(:socat_env) { {} }
+    let(:socat_cmd) { [] }
+
+    around do |example|
+      socat.start
+      Timeout.timeout(5) do
+        example.run
+      end
+      socat.stop
+    end
+
+    shared_examples 'do socat' do
+      it 'should run a command when a connection is established' do
+        Socket.tcp('127.0.0.1', socat.port) do |sock|
+          expect(sock.read).to eq('hello')
+        end
+      end
+
+      it 'should allow running multiple commands in parallel' do
+        q = Queue.new
+
+        threads = (1..10).map do
+          Thread.new do
+            Socket.tcp('127.0.0.1', socat.port) do |sock|
+              q << sock.read
+            end
+          end
+        end
+        threads.each(&:join)
+
+        expect(q.size). to eq(10)
+        (1..10).each { expect(q.deq).to eq('hello') }
+      end
+    end
+
+    context 'fast command' do
+      let(:socat_cmd) { ['echo', '-n', 'hello'] }
+
+      include_examples 'do socat'
+    end
+
+    context 'slow command' do
+      let(:socat_cmd) { ['bash', '-c', 'sleep 2 && echo -n hello'] }
+
+      include_examples 'do socat'
+    end
+
+    context 'with environment' do
+      let(:socat_env) { { 'KEY' => 'VALUE' } }
+      let(:socat_cmd) { ['bash', '-c', 'echo -n "$KEY"'] }
+
+      it 'should passthrough the environment' do
+        Socket.tcp('127.0.0.1', socat.port) do |sock|
+          expect(sock.read).to eq('VALUE')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note: this depends on https://github.com/aptible/broadwayjoe/pull/37 on the backend to work.

This changes two things:

- It uses the SSH tunnel as the data transport, instead of relying on port forwarding. The main benefit of this approach is that it eliminates a race condition in `db:dump` (where `pg_dump` might be run before the tunnel is listening on the remote end).
- It passes a database / app URL for `APTIBLE_DATABASE` and `APTIBLE_APP`, which allows the backend to skip enumerating databases / apps to find a match (it also ensures the backend will always choose the right db / app even if multiple have the same handle).

--

cc @fancyremarker 