### PR TITLE
Signal tunnel ready

### DIFF
--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.0'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'climate_control'
 end

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -8,6 +8,7 @@ require_relative 'helpers/environment'
 require_relative 'helpers/app'
 require_relative 'helpers/database'
 require_relative 'helpers/env'
+require_relative 'helpers/tunnel'
 
 require_relative 'subcommands/apps'
 require_relative 'subcommands/config'

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -44,18 +44,6 @@ module Aptible
           say ''
         end
 
-        def establish_connection(database, local_port)
-          ENV['ACCESS_TOKEN'] = fetch_token
-          ENV['APTIBLE_DATABASE'] = database.handle
-
-          remote_port = claim_remote_port(database)
-          ENV['TUNNEL_PORT'] = remote_port
-
-          tunnel_args = "-L #{local_port}:localhost:#{remote_port}"
-          command = "ssh #{tunnel_args} #{common_ssh_args(database)}"
-          Kernel.exec(command)
-        end
-
         def clone_database(source, dest_handle)
           op = source.create_operation(type: 'clone', handle: dest_handle)
           poll_for_success(op)
@@ -63,35 +51,30 @@ module Aptible
           databases_from_handle(dest_handle, source.account).first
         end
 
-        def dump_database(database)
-          execute_local_tunnel(database) do |url|
-            filename = "#{database.handle}.dump"
-            say "Dumping to #{filename}"
-            `pg_dump #{url} > #{filename}`
+        # Creates a local tunnel and yields the helper
+
+        def with_local_tunnel(database, port = 0)
+          # TODO: Should pass the DB ID...
+          env = {
+            'ACCESS_TOKEN' => fetch_token,
+            'APTIBLE_DATABASE' => database.handle
+          }
+          command = ['ssh', '-q'] + ssh_args(database)
+          Helpers::Tunnel.new(env, command).tap do |tunnel_helper|
+            tunnel_helper.start(port)
+            yield tunnel_helper
+            tunnel_helper.stop
           end
         end
 
-        # Creates a local tunnel and yields the url to it
-        def execute_local_tunnel(database)
-          local_port = random_local_port
-          pid = fork { establish_connection(database, local_port) }
+        # Creates a local PG tunnel and yields the url to it
 
-          # TODO: Better test for connection readiness
-          sleep 10
-
-          auth = "aptible:#{database.passphrase}"
-          host = "localhost:#{local_port}"
-          yield "postgresql://#{auth}@#{host}/db"
-        ensure
-          Process.kill('HUP', pid) if pid
-        end
-
-        def random_local_port
-          # Allocate a dummy server to discover an available port
-          dummy = TCPServer.new('127.0.0.1', 0)
-          port = dummy.addr[1]
-          dummy.close
-          port
+        def with_postgres_tunnel(database)
+          with_local_tunnel(database) do |tunnel_helper|
+            auth = "aptible:#{database.passphrase}"
+            host = "localhost:#{tunnel_helper.port}"
+            yield "postgresql://#{auth}@#{host}/db"
+          end
         end
 
         def local_url(database, local_port)
@@ -102,20 +85,16 @@ module Aptible
           "127.0.0.1:#{local_port}#{uri.path}"
         end
 
-        def claim_remote_port(database)
-          ENV['ACCESS_TOKEN'] = fetch_token
-
-          `ssh #{common_ssh_args(database)} 2>/dev/null`.chomp
-        end
-
-        def common_ssh_args(database)
+        def ssh_args(database)
           host = database.account.bastion_host
           port = database.account.bastion_port
 
-          opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \
-                 '-o UserKnownHostsFile=/dev/null'
-          connection_args = "-p #{port} root@#{host}"
-          "#{opts} #{connection_args}"
+          ['-o', 'SendEnv=APTIBLE_DATABASE',
+           '-o', 'SendEnv=TUNNEL_PORT',
+           '-o', 'SendEnv=ACCESS_TOKEN',
+           '-o', 'StrictHostKeyChecking=no',
+           '-o', 'UserKnownHostsFile=/dev/null',
+           '-p', port.to_s, "root@#{host}"]
         end
       end
     end

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -70,6 +70,10 @@ module Aptible
         # Creates a local PG tunnel and yields the url to it
 
         def with_postgres_tunnel(database)
+          if database.type != 'postgresql'
+            fail Thor::Error, 'This command only works for PostgreSQL'
+          end
+
           with_local_tunnel(database) do |tunnel_helper|
             auth = "aptible:#{database.passphrase}"
             host = "localhost:#{tunnel_helper.port}"

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -93,7 +93,6 @@ module Aptible
           port = database.account.bastion_port
 
           ['-o', 'SendEnv=APTIBLE_DATABASE',
-           '-o', 'SendEnv=TUNNEL_PORT',
            '-o', 'SendEnv=ACCESS_TOKEN',
            '-o', 'StrictHostKeyChecking=no',
            '-o', 'UserKnownHostsFile=/dev/null',

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -54,10 +54,9 @@ module Aptible
         # Creates a local tunnel and yields the helper
 
         def with_local_tunnel(database, port = 0)
-          # TODO: Should pass the DB ID...
           env = {
             'ACCESS_TOKEN' => fetch_token,
-            'APTIBLE_DATABASE' => database.handle
+            'APTIBLE_DATABASE' => database.href
           }
           command = ['ssh', '-q'] + ssh_args(database)
           Helpers::Tunnel.new(env, command).tap do |tunnel_helper|

--- a/lib/aptible/cli/helpers/tunnel.rb
+++ b/lib/aptible/cli/helpers/tunnel.rb
@@ -1,0 +1,68 @@
+require 'socket'
+require 'open3'
+
+module Aptible
+  module CLI
+    module Helpers
+      class Tunnel
+        def initialize(env, cmd)
+          @env = env
+          @cmd = cmd
+        end
+
+        def start(desired_port = 0, err_fd = $stderr)
+          @local_port = desired_port
+          @local_port = random_local_port if @local_port == 0
+
+          # First, grab a remote port
+          out, err, status = Open3.capture3(@env, *@cmd)
+          fail "Failed to request remote port: #{err}" unless status.success?
+
+          # Then, spin up a SSH session using that port and port forwarding
+          remote_port = out.chomp
+          tunnel_env = @env.merge('TUNNEL_PORT' => remote_port)
+          tunnel_cmd = @cmd + ['-L', "#{@local_port}:localhost:#{remote_port}"]
+
+          r_pipe, w_pipe = IO.pipe
+          @pid = Process.spawn(tunnel_env, *tunnel_cmd, in: :close,
+                                                        out: w_pipe,
+                                                        err: err_fd)
+
+          # Wait for the tunnel to come up before returning. The other end
+          # will send a message on stdout to indicate that the tunnel is ready.
+          w_pipe.close
+          begin
+            r_pipe.readline
+          rescue EOFError
+            raise 'Server closed the tunnel'
+          end
+        end
+
+        def stop
+          fail 'You must call #start before calling #stop' if @pid.nil?
+          Process.kill('HUP', @pid)
+          wait
+        end
+
+        def wait
+          Process.wait @pid
+        end
+
+        def port
+          fail 'You must call #start before calling #port!' if @local_port.nil?
+          @local_port
+        end
+
+        private
+
+        def random_local_port
+          # Allocate a dummy server to discover an available port
+          dummy = TCPServer.new('127.0.0.1', 0)
+          port = dummy.addr[1]
+          dummy.close
+          port
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -1,4 +1,5 @@
 require 'term/ansicolor'
+require 'uri'
 
 module Aptible
   module CLI
@@ -49,16 +50,21 @@ module Aptible
             desc 'db:dump HANDLE', 'Dump a remote database to file'
             option :environment
             define_method 'db:dump' do |handle|
+              # TODO: This no longer restricts to PG dbs
               database = ensure_database(options.merge(db: handle))
-              dump_database(database)
+              with_postgres_tunnel(database) do |url|
+                filename = "#{handle}.dump"
+                say "Dumping to #{filename}"
+                `pg_dump #{url} > #{filename}`
+              end
             end
 
             desc 'db:execute HANDLE SQL_FILE', 'Executes sql against a database'
             option :environment
             define_method 'db:execute' do |handle, sql_path|
               database = ensure_database(options.merge(db: handle))
-              execute_local_tunnel(database) do |url|
-                say "Executing #{sql_path} against #{database.handle}"
+              with_postgres_tunnel(database) do |url|
+                say "Executing #{sql_path} against #{handle}"
                 `psql #{url} < #{sql_path}`
               end
             end
@@ -67,21 +73,31 @@ module Aptible
             option :environment
             option :port, type: :numeric
             define_method 'db:tunnel' do |handle|
+              desired_port = Integer(options[:port] || 0)
               database = ensure_database(options.merge(db: handle))
-              local_port = options[:port] || random_local_port
-
               say 'Creating tunnel...', :green
-              say "Connect at #{local_url(database, local_port)}", :green
 
-              uri = URI(local_url(database, local_port))
-              db = uri.path.gsub(%r{^/}, '')
-              say 'Or, use the following arguments:', :green
-              say("* Host: #{uri.host}", :green)
-              say("* Port: #{uri.port}", :green)
-              say("* Username: #{uri.user}", :green) unless uri.user.empty?
-              say("* Password: #{uri.password}", :green)
-              say("* Database: #{db}", :green) unless db.empty?
-              establish_connection(database, local_port)
+              with_local_tunnel(database, desired_port) do |tunnel_helper|
+                port = tunnel_helper.port
+                say "Connect at #{local_url(database, port)}", :green
+
+                uri = URI(local_url(database, port))
+                db = uri.path.gsub(%r{^/}, '')
+                say 'Or, use the following arguments:', :green
+                say("* Host: #{uri.host}", :green)
+                say("* Port: #{uri.port}", :green)
+                say("* Username: #{uri.user}", :green) unless uri.user.empty?
+                say("* Password: #{uri.password}", :green)
+                say("* Database: #{db}", :green) unless db.empty?
+
+                say 'Tunnel ready. Ctrl-C to close connection.'
+
+                begin
+                  tunnel_helper.wait
+                rescue Interrupt
+                  say 'Closing tunnel'
+                end
+              end
             end
 
             desc 'db:deprovision HANDLE', 'Deprovision a database'

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -50,7 +50,6 @@ module Aptible
             desc 'db:dump HANDLE', 'Dump a remote database to file'
             option :environment
             define_method 'db:dump' do |handle|
-              # TODO: This no longer restricts to PG dbs
               database = ensure_database(options.merge(db: handle))
               with_postgres_tunnel(database) do |url|
                 filename = "#{handle}.dump"

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -89,7 +89,7 @@ module Aptible
                 say("* Password: #{uri.password}", :green)
                 say("* Database: #{db}", :green) unless db.empty?
 
-                say 'Tunnel ready. Ctrl-C to close connection.'
+                say 'Connected. Ctrl-C to close connection.'
 
                 begin
                   tunnel_helper.wait

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -23,7 +23,7 @@ module Aptible
               port = app.account.dumptruck_port
 
               ENV['ACCESS_TOKEN'] = fetch_token
-              ENV['APTIBLE_APP'] = app.handle
+              ENV['APTIBLE_APP'] = app.href
               ENV['APTIBLE_CLI_COMMAND'] = 'logs'
 
               opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \

--- a/lib/aptible/cli/subcommands/ps.rb
+++ b/lib/aptible/cli/subcommands/ps.rb
@@ -19,7 +19,7 @@ module Aptible
               port = app.account.dumptruck_port
 
               set_env('ACCESS_TOKEN', fetch_token)
-              set_env('APTIBLE_APP', app.handle)
+              set_env('APTIBLE_APP', app.href)
               set_env('APTIBLE_CLI_COMMAND', 'ps')
 
               opts = " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -24,7 +24,7 @@ module Aptible
 
               ENV['ACCESS_TOKEN'] = fetch_token
               ENV['APTIBLE_COMMAND'] = command_from_args(*args)
-              ENV['APTIBLE_APP'] = app.handle
+              ENV['APTIBLE_APP'] = app.href
 
               opts = options[:force_tty] ? '-t -t' : ''
               opts << " -o 'SendEnv=*' -o StrictHostKeyChecking=no " \

--- a/spec/aptible/cli/helpers/tunnel_spec.rb
+++ b/spec/aptible/cli/helpers/tunnel_spec.rb
@@ -17,9 +17,13 @@ describe Aptible::CLI::Helpers::Tunnel do
     helper.start(0, w)
     helper.stop
 
-    expect(r.readline.chomp).to eq('2')
+    expect(r.readline.chomp).to eq('6')
     expect(r.readline.chomp).to eq('-L')
     expect(r.readline.chomp).to match(/\d+:localhost:1234$/)
+    expect(r.readline.chomp).to eq('-o')
+    expect(r.readline.chomp).to eq('SendEnv=TUNNEL_PORT')
+    expect(r.readline.chomp).to eq('-o')
+    expect(r.readline.chomp).to eq('SendEnv=TUNNEL_SIGNAL_OPEN')
 
     r.close
     w.close
@@ -31,9 +35,13 @@ describe Aptible::CLI::Helpers::Tunnel do
     helper.start(5678, w)
     helper.stop
 
-    expect(r.readline.chomp).to eq('2')
+    expect(r.readline.chomp).to eq('6')
     expect(r.readline.chomp).to eq('-L')
     expect(r.readline.chomp).to eq('5678:localhost:1234')
+    expect(r.readline.chomp).to eq('-o')
+    expect(r.readline.chomp).to eq('SendEnv=TUNNEL_PORT')
+    expect(r.readline.chomp).to eq('-o')
+    expect(r.readline.chomp).to eq('SendEnv=TUNNEL_SIGNAL_OPEN')
 
     r.close
     w.close

--- a/spec/aptible/cli/helpers/tunnel_spec.rb
+++ b/spec/aptible/cli/helpers/tunnel_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'climate_control'
+
+describe Aptible::CLI::Helpers::Tunnel do
+  around do |example|
+    mocks_path = File.expand_path('../../../../mock', __FILE__)
+    path = "#{mocks_path}:#{ENV['PATH']}"
+    ClimateControl.modify PATH: path do
+      example.run
+    end
+  end
+
+  it 'reuses the port it was given' do
+    helper = described_class.new({}, ['ssh_mock.rb'])
+
+    r, w = IO.pipe
+    helper.start(0, w)
+    helper.stop
+
+    expect(r.readline.chomp).to eq('2')
+    expect(r.readline.chomp).to eq('-L')
+    expect(r.readline.chomp).to match(/\d+:localhost:1234$/)
+
+    r.close
+    w.close
+  end
+
+  it 'accepts a desired port' do
+    helper = described_class.new({}, ['ssh_mock.rb'])
+    r, w = IO.pipe
+    helper.start(5678, w)
+    helper.stop
+
+    expect(r.readline.chomp).to eq('2')
+    expect(r.readline.chomp).to eq('-L')
+    expect(r.readline.chomp).to eq('5678:localhost:1234')
+
+    r.close
+    w.close
+  end
+
+  it 'captures and displays port discovery errors' do
+    helper = described_class.new({ 'FAIL_PORT' => '1' }, ['ssh_mock.rb'])
+    expect { helper.start }.to raise_error(/Something went wrong/)
+  end
+
+  it 'captures and displays tunnel errors' do
+    helper = described_class.new({ 'FAIL_TUNNEL' => '1' }, ['ssh_mock.rb'])
+    expect do
+      helper.start(0, File.open(File::NULL, 'w'))
+    end.to raise_error(/Server closed the tunnel/)
+  end
+
+  it 'should fail if #port is called before #start' do
+    socat = described_class.new({}, [])
+    expect { socat.port }.to raise_error(/You must call #start/)
+  end
+
+  it 'should fail if #stop is called before #start' do
+    socat = described_class.new({}, [])
+    expect { socat.stop }.to raise_error(/You must call #start/)
+  end
+end

--- a/spec/mock/ssh_mock.rb
+++ b/spec/mock/ssh_mock.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# Emulate server behavior
+
+if ENV['TUNNEL_PORT']
+  fail 'Something went wrong!' if ENV['FAIL_TUNNEL']
+  puts 'TUNNEL READY'
+else
+  fail 'Something went wrong!' if ENV['FAIL_PORT']
+  puts 1234
+end
+
+# Log to stderr so we can collect in test
+
+$stderr.puts ARGV.size
+ARGV.each do |a|
+  $stderr.puts a
+end


### PR DESCRIPTION
This updates the CLI so that it waits for a message from the backend before reporting the tunnel is ready when using `db:tunnel` and related commands.

The message can either be the `TUNNEL READY` one sent by https://github.com/aptible/broadwayjoe/pull/39, or we could simply roll back the SSH data transport changes and capture `Connected. Ctrl-C to close connection` instead.

This also refactors the way tunnels are stood up a little bit (to take advantage of the fact that the tunnel is now able to report that it's up).

cc @fancyremarker 