### PR TITLE
Do not update DB status on deprovision

### DIFF
--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -89,7 +89,6 @@ module Aptible
             define_method 'db:deprovision' do |handle|
               database = ensure_database(options.merge(db: handle))
               say "Deprovisioning #{database.handle}..."
-              database.update!(status: 'deprovisioned')
               database.create_operation!(type: 'deprovision')
             end
           end


### PR DESCRIPTION
This is similar to https://github.com/aptible/dashboard.aptible.com/pull/560. It's another case where an API client tries to set an attribute it should not have access to (more context in https://github.com/aptible/auth.aptible.com/pull/203).

Note: this doesn't *need* to be changed for us to be able to roll out privileged tokens (the attribute update will silently be ignored).

cc @fancyremarker