### PR TITLE
apps:scale - Error out when service isn't found

### DIFF
--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -39,6 +39,16 @@ module Aptible
               num = Integer(n)
               app = ensure_app(options)
               service = app.services.find { |s| s.process_type == type }
+              if service.nil?
+                valid_types = if app.services.empty?
+                                'NONE (deploy the app first)'
+                              else
+                                app.services.map(&:process_type).join(', ')
+                              end
+                fail Thor::Error, "Service with type #{type} does not " \
+                                  "exist for app #{app.handle}. Valid " \
+                                  "types: #{valid_types}."
+              end
               op = service.create_operation(type: 'scale', container_count: num)
               attach_to_operation_logs(op)
             end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -26,8 +26,9 @@ describe Aptible::CLI::Agent do
                 dumptruck_port: 1234,
                 handle: 'aptible')
   end
+  let(:services) { [service] }
   let(:apps) do
-    [App.new(handle: 'hello', services: [service], account: account)]
+    [App.new(handle: 'hello', services: services, account: account)]
   end
 
   describe '#apps:scale' do
@@ -69,6 +70,28 @@ describe Aptible::CLI::Agent do
       expect do
         subject.send('apps:scale', 'web', 'potato')
       end.to raise_error(ArgumentError)
+    end
+
+    it 'should fail if the service does not exist' do
+      allow(subject).to receive(:options) { { app: 'hello' } }
+      allow(Aptible::Api::App).to receive(:all) { apps }
+
+      expect do
+        subject.send('apps:scale', 'potato', 1)
+      end.to raise_error(Thor::Error, /Service.* potato.* does not exist/)
+    end
+
+    context 'no service' do
+      let(:services) { [] }
+
+      it 'should fail if the app has no services' do
+        allow(subject).to receive(:options) { { app: 'hello' } }
+        allow(Aptible::Api::App).to receive(:all) { apps }
+
+        expect do
+          subject.send('apps:scale', 'web', 1)
+        end.to raise_error(Thor::Error, /deploy the app first/)
+      end
     end
   end
 end


### PR DESCRIPTION
The current behavior is to go on and crash at service.create_operation,
which results in a somewhat cryptic error (see ZD 5202). This patch
updates apps:scale to instead explain the problem and display a list of
services that would have been valid.

cc @fancyremarker