### PR TITLE
Add size option when scaling app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@ source 'https://rubygems.org'
 
 gem 'pry', github: 'fancyremarker/pry', branch: 'aptible'
 
+group :test do
+  gem 'webmock'
+end
+
 # Specify your gem's dependencies in aptible-cli.gemspec
 gemspec

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -35,6 +35,14 @@ module Aptible
 
             desc 'apps:scale TYPE NUMBER', 'Scale app to NUMBER of instances'
             app_options
+            option :size, type: :numeric, enum: [512,
+                                                 1024,
+                                                 2048,
+                                                 4096,
+                                                 8192,
+                                                 16384,
+                                                 32768,
+                                                 65536]
             define_method 'apps:scale' do |type, n|
               num = Integer(n)
               app = ensure_app(options)
@@ -49,7 +57,9 @@ module Aptible
                                   "exist for app #{app.handle}. Valid " \
                                   "types: #{valid_types}."
               end
-              op = service.create_operation(type: 'scale', container_count: num)
+              op = service.create_operation(type: 'scale',
+                                            container_count: num,
+                                            container_size: options[:size])
               attach_to_operation_logs(op)
             end
 

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.6.4'
+    VERSION = '0.6.5'
   end
 end

--- a/spec/aptible/cli/subcommands/domains_spec.rb
+++ b/spec/aptible/cli/subcommands/domains_spec.rb
@@ -33,8 +33,14 @@ describe Aptible::CLI::Agent do
 
   describe '#domains' do
     it 'should print out the hostnames' do
+      expect(subject).to receive(:environment_from_handle)
+        .with('foobar')
+        .and_return(account)
+      expect(subject).to receive(:apps_from_handle).and_return(apps)
       allow(service).to receive(:create_operation) { op }
-      allow(subject).to receive(:options) { { app: 'hello' } }
+      allow(subject).to receive(:options) do
+        { environment: 'foobar', app: 'web' }
+      end
       allow(Aptible::Api::App).to receive(:all) { apps }
 
       expect(app).to receive(:vhosts) { [vhost1, vhost2] }
@@ -65,8 +71,14 @@ describe Aptible::CLI::Agent do
     end
 
     it 'should print hostnames if -v is passed' do
+      expect(subject).to receive(:environment_from_handle)
+        .with('foobar')
+        .and_return(account)
+      expect(subject).to receive(:apps_from_handle).and_return(apps)
       allow(service).to receive(:create_operation) { op }
-      allow(subject).to receive(:options) { { verbose: true, app: 'hello' } }
+      allow(subject).to receive(:options) do
+        { verbose: true, app: 'hello', environment: 'foobar' }
+      end
       allow(Aptible::Api::App).to receive(:all) { apps }
 
       expect(app).to receive(:vhosts) { [vhost1, vhost2] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
+require 'webmock/rspec'
+
 # Load shared spec files
 Dir["#{File.dirname(__FILE__)}/shared/**/*.rb"].each do |file|
   require file


### PR DESCRIPTION
This commit adds an optional --size parameter, which can be used to
set a memory limit on the service that is being scaled, as in the
dashboard. If not specified, the service will either whatever default
it previously had, or whatever Sweetness has set as default.

This commit also adds Webmock to the specs, since there are some
inadvertent calls that are being made to our api.

cc @fancyremarker