### PR TITLE
Check for token in APTIBLE_ACCESS_TOKEN

### DIFF
--- a/lib/aptible/cli/helpers/token.rb
+++ b/lib/aptible/cli/helpers/token.rb
@@ -4,10 +4,14 @@ module Aptible
   module CLI
     module Helpers
       module Token
+        TOKEN_ENV_VAR = 'APTIBLE_ACCESS_TOKEN'
+
         def fetch_token
-          @token ||= current_token_hash[Aptible::Auth.configuration.root_url]
+          @token ||= ENV[TOKEN_ENV_VAR] ||
+                     current_token_hash[Aptible::Auth.configuration.root_url]
           return @token if @token
-          fail Thor::Error, 'Could not read token: please run aptible login'
+          fail Thor::Error, 'Could not read token: please run aptible login ' \
+                            "or set #{TOKEN_ENV_VAR}"
         end
 
         def save_token(token)


### PR DESCRIPTION
For unattended operation, it's easier to pass a token via the
environment rather than generate a JSON file in HOME and remember to
delete it, or use `aptible login`.

This change lets the aptible CLI look for a token in the
APTIBLE_ACCESS_TOKEN environment variable. The variable takes precedence
over the Aptible configuration file to allow for predictable behavior
when running on a host where there is also a configuration file.

In particular, this feature is useful to use the aptible cli in
integration tests.

--

cc @fancyremarker 