### PR TITLE
Remove deprecation notice for aptible logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Commands:
   aptible domains                     # Print an app's current virtual domains
   aptible help [COMMAND]              # Describe available commands or one specific command
   aptible login                       # Log in to Aptible
-  aptible logs                        # Follows logs from a running app - DEPRECATED
+  aptible logs                        # Follows logs from a running app
   aptible ps                          # Display running processes for an app - DEPRECATED
   aptible rebuild                     # Rebuild an app, and restart its services
   aptible restart                     # Restart all services associated with an app

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -9,11 +9,10 @@ module Aptible
             include Helpers::Operation
             include Helpers::App
 
-            desc 'logs', 'Follows logs from a running app - DEPRECATED'
+            desc 'logs', 'Follows logs from a running app'
             app_options
             def logs
               app = ensure_app(options)
-              deprecated('This command is deprecated on Aptible v2 stacks.')
               unless app.status == 'provisioned' && app.services.any?
                 fail Thor::Error, 'Unable to retrieve logs. ' \
                                   "Have you deployed #{app.handle} yet?"


### PR DESCRIPTION
Because it will soon no longer deprecated!

cc @fancyremarker 