### PR TITLE
fix: re-route stderr correctly for windows

### DIFF
--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -104,8 +104,9 @@ module Aptible
 
         def claim_remote_port(database)
           ENV['ACCESS_TOKEN'] = fetch_token
+          null_directory = Gem.win_platform? ? 'nul' : '/dev/null'
 
-          `ssh #{common_ssh_args(database)} 2>/dev/null`.chomp
+          `ssh #{common_ssh_args(database)} 2>#{null_directory}`.chomp
         end
 
         def common_ssh_args(database)


### PR DESCRIPTION
This allows anyone using the `ssh` binary that ships with msysgit to successfully establish a tunnel