### PR TITLE
Explain environment guesses to the user

### DIFF
--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -54,7 +54,18 @@ module Aptible
           when 1
             return apps.first
           when 0
-            fail Thor::Error, "Could not find app #{app_handle}"
+            err_bits = ["Could not find app #{app_handle}"]
+
+            if environment_handle
+              err_bits << "in environment #{environment_handle}"
+              unless options[:environment]
+                # We guessed the environment, and our guess might have been
+                # wrong, let the user know.
+                err_bits << '(NOTE: environment was derived from git remote ' \
+                            "#{remote}, use --environment to override)"
+              end
+            end
+            fail Thor::Error, err_bits.join(' ')
           else
             fail Thor::Error, 'Multiple apps exist, please specify environment'
           end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -133,4 +133,76 @@ describe Aptible::CLI::Agent do
       end
     end
   end
+
+  describe 'ensure_app' do
+    let(:app) { apps.first }
+
+    let(:stub_remote) { {} }
+    let(:stub_env) { nil }
+    let(:stub_apps) { [] }
+
+    before do
+      allow(subject).to receive(:handles_from_remote).and_return(stub_remote)
+      allow(subject).to receive(:environment_from_handle).and_return(stub_env)
+      allow(subject).to receive(:apps_from_handle).and_return(stub_apps)
+    end
+
+    context 'with handles from remote' do
+      let(:stub_remote) do
+        { app_handle: app.handle, environment_handle: account.handle }
+      end
+
+      it 'fails if it cannot find the environment' do
+        expect { subject.ensure_app }.to raise_error(/Could not find env/)
+      end
+
+      context 'with an environment' do
+        let(:stub_env) { account }
+
+        it 'fails if it cannot find an app, and explains its guess' do
+          err = /Could not.*app hello.*environment aptible.*remote aptible/
+          expect { subject.ensure_app }.to raise_error(err)
+        end
+
+        it 'fails but does not explain its guess if it did not guess' do
+          e = 'Could not find app hello in environment aptible'
+          expect { subject.ensure_app(environment: 'aptible') }
+            .to raise_error(e)
+        end
+
+        context 'with an app' do
+          let(:stub_apps) { apps }
+
+          it 'succeeds if it finds the app' do
+            expect(subject.ensure_app).to eq(app)
+          end
+        end
+      end
+    end
+
+    context 'without handles from remote' do
+      it 'fails without further handle info' do
+        expect { subject.ensure_app }
+          .to raise_error(/Could not find app in current/)
+      end
+
+      it "fails when passed an environment that's not found" do
+        expect { subject.ensure_app(app: 'hello', environment: 'aptible') }
+          .to raise_error('Could not find environment aptible')
+      end
+
+      it "fails when passed an app that's not found" do
+        expect { subject.ensure_app(app: 'hello') }
+          .to raise_error('Could not find app hello')
+      end
+
+      context 'with an app' do
+        let(:stub_apps) { apps }
+
+        it 'succeeds when passed a app handle' do
+          expect(subject.ensure_app(app: 'hello')).to eq(app)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
We've had several tickets recently that came up due to customers not
realizing (and who could blame them) that even if they provide an app
handle and no environment, we're overriding their choice of environment
based on the current git remote.

This patch updates the aptible CLI to explain the decisions it makes,
and specifically to explain what environment it looked in (if it did
scope its search to a single environment), and where that came from.

---

Another solution would be to *not* guess the environment from the git remote when an app handle is provided (i.e. either guess *everything* or *nothing*). I avoided that solution to avoid breaking backwards compatibility, but it might make sense too. Let me know what you think.

cc @wcpines @fancyremarker 