### PR TITLE
Backups: restore, list, create

### DIFF
--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'climate_control'
+  spec.add_development_dependency 'fabrication', '~> 2.15.2'
 end

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-api', '>= 0.9.5'
-  spec.add_dependency 'aptible-auth', '>= 0.11.3'
-  spec.add_dependency 'thor', '>= 0.19.0'
+  spec.add_dependency 'aptible-api', '~> 0.9.7'
+  spec.add_dependency 'aptible-auth', '~> 0.11.7'
+  spec.add_dependency 'aptible-resource', '~> 0.3.6'
+  spec.add_dependency 'thor', '~> 0.19.1'
   spec.add_dependency 'git'
   spec.add_dependency 'term-ansicolor'
   spec.add_dependency 'chronic_duration', '~> 0.10.6'

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '>= 0.19.0'
   spec.add_dependency 'git'
   spec.add_dependency 'term-ansicolor'
+  spec.add_dependency 'chronic_duration', '~> 0.10.6'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -19,6 +19,7 @@ require_relative 'subcommands/ps'
 require_relative 'subcommands/rebuild'
 require_relative 'subcommands/restart'
 require_relative 'subcommands/ssh'
+require_relative 'subcommands/backup'
 
 module Aptible
   module CLI
@@ -37,6 +38,7 @@ module Aptible
       include Subcommands::Rebuild
       include Subcommands::Restart
       include Subcommands::SSH
+      include Subcommands::Backup
 
       # Forward return codes on failures.
       def self.exit_on_failure?

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -1,6 +1,7 @@
 require 'aptible/auth'
 require 'thor'
 require 'json'
+require 'chronic_duration'
 
 require_relative 'helpers/token'
 require_relative 'helpers/operation'

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -1,0 +1,48 @@
+module Aptible
+  module CLI
+    module Subcommands
+      module Backup
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::Token
+            include Helpers::Database
+
+            desc 'backup:restore [--handle HANDLE] [--size SIZE_GB]',
+                 'Restore a backup'
+            option :handle
+            option :size, type: :numeric
+            define_method 'backup:restore' do |backup_id|
+              backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
+              fail Thor::Error, "Backup ##{backup_id} not found" if backup.nil?
+              handle = options[:handle]
+              unless handle
+                ts_suffix = backup.created_at.getgm.strftime '%Y-%m-%d-%H-%M-%S'
+                handle = "#{backup.database.handle}-at-#{ts_suffix}"
+              end
+
+              opts = {
+                type: 'restore',
+                handle: handle,
+                disk_size: options[:size]
+              }.delete_if { |_, v| v.nil? }
+
+              operation = backup.create_operation!(opts)
+              say "Restoring backup into #{handle}"
+              attach_to_operation_logs(operation)
+            end
+
+            desc 'backup:list DB_HANDLE', 'List backups for a database'
+            option :environment
+            define_method 'backup:list' do |handle|
+              # TODO: Expose pagination from aptible-resource
+              database = ensure_database(options.merge(db: handle))
+              database.backups.each do |backup|
+                say "#{backup.id}: #{backup.created_at}, #{backup.aws_region}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -106,6 +106,15 @@ module Aptible
               say "Deprovisioning #{database.handle}..."
               database.create_operation!(type: 'deprovision')
             end
+
+            desc 'db:backup HANDLE', 'Backup a database'
+            option :environment
+            define_method 'db:backup' do |handle|
+              database = ensure_database(options.merge(db: handle))
+              say "Backing up #{database.handle}..."
+              op = database.create_operation!(type: 'backup')
+              attach_to_operation_logs(op)
+            end
           end
         end
       end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -1,17 +1,4 @@
-require 'ostruct'
 require 'spec_helper'
-
-class App < OpenStruct
-end
-
-class Service < OpenStruct
-end
-
-class Operation < OpenStruct
-end
-
-class Account < OpenStruct
-end
 
 describe Aptible::CLI::Agent do
   before { subject.stub(:ask) }
@@ -19,49 +6,40 @@ describe Aptible::CLI::Agent do
   before { subject.stub(:fetch_token) { double 'token' } }
   before { subject.stub(:attach_to_operation_logs) }
 
-  let(:service) { Service.new(process_type: 'web') }
-  let(:op) { Operation.new(status: 'succeeded') }
-  let(:account) do
-    Account.new(bastion_host: 'localhost',
-                dumptruck_port: 1234,
-                handle: 'aptible')
-  end
-  let(:services) { [service] }
-  let(:apps) do
-    [App.new(handle: 'hello', services: services, account: account)]
-  end
+  let!(:account) { Fabricate(:account) }
+  let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
+  let!(:service) { Fabricate(:service, app: app) }
+  let(:op) { Fabricate(:operation, status: 'succeeded', resource: app) }
 
   describe '#apps:scale' do
+    before do
+      allow(Aptible::Api::App).to receive(:all) { [app] }
+      allow(Aptible::Api::Account).to receive(:all) { [account] }
+    end
+
     it 'should pass given correct parameters' do
-      allow(service).to receive(:create_operation!) { op }
       allow(subject).to receive(:options) do
         { app: 'hello', environment: 'foobar' }
       end
-      allow(op).to receive(:resource) { apps.first }
-      allow(Aptible::Api::App).to receive(:all) { apps }
-
+      expect(service).to receive(:create_operation!) { op }
       expect(subject).to receive(:environment_from_handle)
         .with('foobar')
         .and_return(account)
-      expect(subject).to receive(:apps_from_handle).and_return(apps)
+      expect(subject).to receive(:apps_from_handle).and_return([app])
       subject.send('apps:scale', 'web', 3)
     end
 
     it 'should pass container size param to operation if given' do
-      expect(service).to receive(:create_operation!)
-        .with(type: 'scale', container_count: 3, container_size: 90210)
-        .and_return(op)
       allow(subject).to receive(:options) do
         { app: 'hello', size: 90210, environment: 'foobar' }
       end
-
-      allow(op).to receive(:resource) { apps.first }
-      allow(Aptible::Api::App).to receive(:all) { apps }
-
+      expect(service).to receive(:create_operation!)
+        .with(type: 'scale', container_count: 3, container_size: 90210)
+        .and_return(op)
       expect(subject).to receive(:environment_from_handle)
         .with('foobar')
         .and_return(account)
-      expect(subject).to receive(:apps_from_handle).and_return(apps)
+      expect(subject).to receive(:apps_from_handle).and_return([app])
       subject.send('apps:scale', 'web', 3)
     end
 
@@ -69,9 +47,8 @@ describe Aptible::CLI::Agent do
       allow(subject).to receive(:options) do
         { environment: 'foo', app: 'web' }
       end
-      allow(service).to receive(:create_operation!) { op }
       allow(Aptible::Api::Account).to receive(:all) { [] }
-      allow(account).to receive(:apps) { [apps] }
+      allow(service).to receive(:create_operation!) { op }
 
       expect do
         subject.send('apps:scale', 'web', 3)
@@ -79,19 +56,14 @@ describe Aptible::CLI::Agent do
     end
 
     it 'should fail if app is non-existent' do
-      allow(service).to receive(:create_operation!) { op }
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
-      allow(account).to receive(:apps) { [] }
-
       expect do
         subject.send('apps:scale', 'web', 3)
       end.to raise_error(Thor::Error)
     end
 
     it 'should fail if number is not a valid number' do
-      allow(service).to receive(:create_operation!) { op }
       allow(subject).to receive(:options) { { app: 'hello' } }
-      allow(Aptible::Api::App).to receive(:all) { apps }
+      allow(service).to receive(:create_operation) { op }
 
       expect do
         subject.send('apps:scale', 'web', 'potato')
@@ -105,8 +77,7 @@ describe Aptible::CLI::Agent do
       expect(subject).to receive(:environment_from_handle)
         .with('foobar')
         .and_return(account)
-      expect(subject).to receive(:apps_from_handle).and_return(apps)
-      allow(Aptible::Api::App).to receive(:all) { apps }
+      expect(subject).to receive(:apps_from_handle).and_return([app])
 
       expect do
         subject.send('apps:scale', 'potato', 1)
@@ -114,18 +85,16 @@ describe Aptible::CLI::Agent do
     end
 
     context 'no service' do
-      let(:services) { [] }
+      before { app.services = [] }
 
       it 'should fail if the app has no services' do
-        expect(subject).to receive(:environment_from_handle)
-          .with('foobar')
-          .and_return(account)
-        expect(subject).to receive(:apps_from_handle).and_return(apps)
         allow(subject).to receive(:options) do
           { app: 'hello', environment: 'foobar' }
         end
-
-        allow(Aptible::Api::App).to receive(:all) { apps }
+        expect(subject).to receive(:environment_from_handle)
+          .with('foobar')
+          .and_return(account)
+        expect(subject).to receive(:apps_from_handle).and_return([app])
 
         expect do
           subject.send('apps:scale', 'web', 1)

--- a/spec/aptible/cli/subcommands/backup_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  let(:token) { 'some-token' }
+  let(:account) { Fabricate(:account) }
+  let(:database) { Fabricate(:database, account: account, handle: 'some-db') }
+  let!(:backup) do
+    # created_at: 2016-06-14 13:24:11 +0000
+    Fabricate(:backup, database: database, created_at: Time.at(1465910651))
+  end
+
+  let(:messages) { [] }
+
+  before do
+    allow(subject).to receive(:fetch_token).and_return(token)
+    allow(subject).to receive(:say) { |m| messages << m }
+  end
+
+  describe '#backup:restore' do
+    it 'fails if the backup cannot be found' do
+      expect(Aptible::Api::Backup).to receive(:find).with(1, token: token)
+        .and_return(nil)
+
+      expect { subject.send('backup:restore', 1) }
+        .to raise_error('Backup #1 not found')
+    end
+
+    context 'successful restore' do
+      let(:op) { Fabricate(:operation, resource: backup) }
+
+      before do
+        expect(Aptible::Api::Backup).to receive(:find).with(1, token: token)
+          .and_return(backup)
+        expect(subject).to receive(:attach_to_operation_logs).with(op)
+      end
+
+      it 'provides a default handle and no disk size' do
+        h = 'some-db-at-2016-06-14-13-24-11'
+
+        expect(backup).to receive(:create_operation!) do |options|
+          expect(options[:handle]).to eq(h)
+          expect(options[:disk_size]).not_to be_present
+          op
+        end
+
+        subject.send('backup:restore', 1)
+        expect(messages).to eq(["Restoring backup into #{h}"])
+      end
+
+      it 'accepts a custom handle and disk size' do
+        h = 'some-handle'
+        s = 40
+
+        expect(backup).to receive(:create_operation!) do |options|
+          expect(options[:handle]).to eq(h)
+          expect(options[:disk_size]).to eq(s)
+          op
+        end
+
+        subject.options = { handle: h, size: s }
+        subject.send('backup:restore', 1)
+        expect(messages).to eq(["Restoring backup into #{h}"])
+      end
+    end
+  end
+
+  describe '#backup:list' do
+    before { 10.times { Fabricate(:backup, database: database) } }
+    before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
+    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
+
+    it 'shows backups for a database' do
+      subject.send('backup:list', database.handle)
+      expect(messages.size).to eq(11)
+    end
+
+    it 'allows scoping via environment' do
+      subject.options = { environment: database.account.handle }
+      subject.send('backup:list', database.handle)
+      expect(messages.size).to eq(11)
+    end
+
+    it 'fails if the DB is not found' do
+      expect { subject.send('backup:list', 'nope') }
+        .to raise_error(Thor::Error, 'Could not find database nope')
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -95,4 +95,24 @@ describe Aptible::CLI::Agent do
       end
     end
   end
+
+  describe '#db:backup' do
+    before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
+    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
+
+    let(:op) { Fabricate(:operation) }
+
+    it 'allows creating a new backup' do
+      expect(database).to receive(:create_operation!).and_return(op)
+      expect(subject).to receive(:say).with('Backing up foobar...')
+      expect(subject).to receive(:attach_to_operation_logs).with(op)
+
+      subject.send('db:backup', handle)
+    end
+
+    it 'fails if the DB is not found' do
+      expect { subject.send('db:backup', 'nope') }
+        .to raise_error(Thor::Error, 'Could not find database nope')
+    end
+  end
 end

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -1,11 +1,4 @@
-require 'ostruct'
 require 'spec_helper'
-
-class Database < OpenStruct
-end
-
-class Account < OpenStruct
-end
 
 class SocatHelperMock < OpenStruct
 end
@@ -15,33 +8,16 @@ describe Aptible::CLI::Agent do
   before { subject.stub(:save_token) }
   before { subject.stub(:fetch_token) { double 'token' } }
 
-  let(:account) do
-    Account.new(bastion_host: 'localhost',
-                dumptruck_port: 1234,
-                handle: 'aptible')
-  end
-  let(:database) do
-    Database.new(
-      type: 'postgresql',
-      handle: 'foobar',
-      passphrase: 'password',
-      connection_url: 'postgresql://aptible:password@10.252.1.125:49158/db',
-      account: account
-    )
-  end
-
-  let(:socat_helper) do
-    SocatHelperMock.new(
-      port: 4242
-    )
-  end
+  let(:handle) { 'foobar' }
+  let(:database) { Fabricate(:database, handle: handle) }
+  let(:socat_helper) { SocatHelperMock.new(port: 4242) }
 
   describe '#db:tunnel' do
     it 'should fail if database is non-existent' do
       allow(Aptible::Api::Database).to receive(:all) { [] }
       expect do
-        subject.send('db:tunnel', 'foobar')
-      end.to raise_error('Could not find database foobar')
+        subject.send('db:tunnel', handle)
+      end.to raise_error("Could not find database #{handle}")
     end
 
     it 'should print a message about how to connect' do
@@ -55,14 +31,28 @@ describe Aptible::CLI::Agent do
 
       # db:tunnel should also explain each component of the URL:
       expect(subject).to receive(:say).exactly(7).times
-      subject.send('db:tunnel', 'foobar')
+      subject.send('db:tunnel', handle)
     end
   end
 
   describe '#db:list' do
+    before do
+      staging = Fabricate(:account, handle: 'staging')
+      prod = Fabricate(:account, handle: 'production')
+
+      [[staging, 'staging-redis-db'], [staging, 'staging-postgres-db'],
+       [prod, 'prod-elsearch-db'], [prod, 'prod-postgres-db']].each do |a, h|
+        Fabricate(:database, account: a, handle: h)
+      end
+
+      token = 'the-token'
+      allow(subject).to receive(:fetch_token).and_return(token)
+      allow(Aptible::Api::Account).to receive(:all).with(token: token)
+        .and_return([staging, prod])
+    end
+
     context 'when no account is specified' do
       it 'prints out the grouped database handles for all accounts' do
-        setup_prod_and_staging_accounts
         allow(subject).to receive(:say)
 
         subject.send('db:list')
@@ -79,7 +69,6 @@ describe Aptible::CLI::Agent do
 
     context 'when a valid account is specified' do
       it 'prints out the database handles for the account' do
-        setup_prod_and_staging_accounts
         allow(subject).to receive(:say)
 
         subject.options = { environment: 'staging' }
@@ -97,7 +86,6 @@ describe Aptible::CLI::Agent do
 
     context 'when an invalid account is specified' do
       it 'prints out an error' do
-        setup_prod_and_staging_accounts
         allow(subject).to receive(:say)
 
         subject.options = { environment: 'foo' }
@@ -106,39 +94,5 @@ describe Aptible::CLI::Agent do
         )
       end
     end
-  end
-
-  def setup_prod_and_staging_accounts
-    staging_redis = Database.new(handle: 'staging-redis-db')
-    staging_postgres = Database.new(handle: 'staging-postgres-db')
-    prod_elsearch = Database.new(handle: 'prod-elsearch-db')
-    prod_postgres = Database.new(handle: 'prod-postgres-db')
-
-    stub_local_token_with('the-token')
-    setup_new_accounts_with_dbs(
-      token: 'the-token',
-      account_db_mapping: {
-        'staging' => [staging_redis, staging_postgres],
-        'production' => [prod_elsearch, prod_postgres]
-      }
-    )
-  end
-
-  def setup_new_accounts_with_dbs(options)
-    token = options.fetch(:token)
-    account_db_mapping = options.fetch(:account_db_mapping)
-
-    accounts_with_dbs = []
-    account_db_mapping.each do |account_handle, dbs|
-      account = Account.new(handle: account_handle, databases: dbs)
-      accounts_with_dbs << account
-    end
-
-    allow(Aptible::Api::Account).to receive(:all).with(token: token)
-      .and_return(accounts_with_dbs)
-  end
-
-  def stub_local_token_with(token)
-    allow(subject).to receive(:fetch_token).and_return(token)
   end
 end

--- a/spec/aptible/cli/subcommands/logs_spec.rb
+++ b/spec/aptible/cli/subcommands/logs_spec.rb
@@ -1,33 +1,28 @@
-require 'ostruct'
 require 'spec_helper'
-
-class App < OpenStruct
-end
-
-class Service < OpenStruct
-end
 
 describe Aptible::CLI::Agent do
   before { subject.stub(:ask) }
   before { subject.stub(:save_token) }
   before { subject.stub(:fetch_token) { double 'token' } }
 
-  let(:service) { Service.new(process_type: 'web') }
-  let(:app) do
-    App.new(handle: 'foobar', status: 'provisioned', services: [service])
-  end
+  let!(:app) { Fabricate(:app, handle: 'foobar') }
+  let!(:service) { Fabricate(:service, app: app) }
 
   describe '#logs' do
+    before { allow(Aptible::Api::Account).to receive(:all) { [app.account] } }
+    before { allow(Aptible::Api::App).to receive(:all) { [app] } }
+    before { subject.options = { app: app.handle } }
+
     it 'should fail if the app is unprovisioned' do
-      allow(app).to receive(:status) { 'pending' }
-      allow(subject).to receive(:ensure_app) { app }
-      expect { subject.send('logs') }.to raise_error(Thor::Error)
+      app.status = 'pending'
+      expect { subject.send('logs') }
+        .to raise_error(Thor::Error, /Have you deployed foobar yet/)
     end
 
     it 'should fail if the app has no services' do
-      allow(app).to receive(:services) { [] }
-      allow(subject).to receive(:ensure_app) { app }
-      expect { subject.send('logs') }.to raise_error(Thor::Error)
+      app.services = []
+      expect { subject.send('logs') }
+        .to raise_error(Thor::Error, /Have you deployed foobar yet/)
     end
   end
 end

--- a/spec/aptible/cli/subcommands/ps_spec.rb
+++ b/spec/aptible/cli/subcommands/ps_spec.rb
@@ -1,24 +1,17 @@
-require 'ostruct'
 require 'spec_helper'
 
-class App < OpenStruct
-end
-
-class Account < OpenStruct
-end
-
 describe Aptible::CLI::Agent do
+  let(:account) do
+    Fabricate(:account, bastion_host: 'bastion.com', dumptruck_port: 45022)
+  end
+  let(:app) { Fabricate(:app, account: account) }
+
   before { subject.stub(:ask) }
   before { subject.stub(:save_token) }
   before { subject.stub(:fetch_token) { double 'token' } }
   before { subject.stub(:ensure_app) { app } }
   before { subject.stub(:set_env) }
   before { Kernel.stub(:exec) }
-
-  let(:account) do
-    Account.new(bastion_host: 'bastion.com', dumptruck_port: 45022)
-  end
-  let(:app) { App.new(handle: 'hello', account: account) }
 
   describe '#ps' do
     it 'should set ENV["APTIBLE_CLI_COMMAND"]' do

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,0 +1,10 @@
+class StubAccount < OpenStruct; end
+
+Fabricator(:account, from: :stub_account) do
+  bastion_host 'localhost'
+  dumptruck_port 1234
+  handle 'aptible'
+
+  apps { [] }
+  databases { [] }
+end

--- a/spec/fabricators/app_fabricator.rb
+++ b/spec/fabricators/app_fabricator.rb
@@ -1,0 +1,14 @@
+class StubApp < OpenStruct
+  def vhosts
+    services.map(&:vhosts).flatten
+  end
+end
+
+Fabricator(:app, from: :stub_app) do
+  handle 'hello'
+  status 'provisioned'
+  account
+  services { [] }
+
+  after_create { |app| app.account.apps << app }
+end

--- a/spec/fabricators/backup_fabricator.rb
+++ b/spec/fabricators/backup_fabricator.rb
@@ -1,0 +1,10 @@
+class StubBackup < OpenStruct; end
+
+Fabricator(:backup, from: :stub_backup) do
+  id { sequence(:backup_id) }
+  aws_region { %w(us-east-1 us-west-1).sample }
+  created_at { Time.now }
+  database
+
+  after_create { |backup| backup.database.backups << backup }
+end

--- a/spec/fabricators/database_fabricator.rb
+++ b/spec/fabricators/database_fabricator.rb
@@ -9,5 +9,7 @@ Fabricator(:database, from: :stub_database) do
   connection_url 'postgresql://aptible:password@10.252.1.125:49158/db'
   account
 
+  backups { [] }
+
   after_create { |database| database.account.databases << database }
 end

--- a/spec/fabricators/database_fabricator.rb
+++ b/spec/fabricators/database_fabricator.rb
@@ -1,0 +1,13 @@
+class StubDatabase < OpenStruct; end
+
+Fabricator(:database, from: :stub_database) do
+  type 'postgresql'
+  handle do |attrs|
+    Fabricate.sequence(:database) { |i| "#{attrs[:type]}-#{i}" }
+  end
+  passphrase 'password'
+  connection_url 'postgresql://aptible:password@10.252.1.125:49158/db'
+  account
+
+  after_create { |database| database.account.databases << database }
+end

--- a/spec/fabricators/operation_fabricator.rb
+++ b/spec/fabricators/operation_fabricator.rb
@@ -1,0 +1,6 @@
+class StubOperation < OpenStruct; end
+
+Fabricator(:operation, from: :stub_operation) do
+  status 'queued'
+  resource { Fabricate(:app) }
+end

--- a/spec/fabricators/service_fabricator.rb
+++ b/spec/fabricators/service_fabricator.rb
@@ -1,0 +1,9 @@
+class StubService < OpenStruct; end
+
+Fabricator(:service, from: :stub_service) do
+  process_type 'web'
+  app
+  vhosts { [] }
+
+  after_create { |service| service.app.services << service }
+end

--- a/spec/fabricators/vhost_fabricator.rb
+++ b/spec/fabricators/vhost_fabricator.rb
@@ -1,0 +1,9 @@
+class StubVhost < OpenStruct; end
+
+Fabricator(:vhost, from: :stub_vhost) do
+  virtual_domain 'domain1'
+  external_host 'host1'
+  service
+
+  after_create { |vhost| vhost.service.vhosts << vhost }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'webmock/rspec'
+Bundler.require :development
 
 require 'simplecov'
 SimpleCov.start


### PR DESCRIPTION
There are two things in this PR:

- (More important) A few new commands:
  - `db:backup HANDLE`: creates a new DB backup.
  - `backup:list HANDLE`: lists backups for a DB.
  - `backup:restore ID`: restores a backup.
- Refactoring of our specs to use fabricators and reduce the need for stubbing. It doesn't eliminate all stubbing (ideally I'd want to be able to get rid of all the `allow(Aptible::Api::App).to receive(:all) { [app] }`), but it reduces it quite a bit.

Probably worth discussing is the naming of the commands. I feel pretty strongly that we don't want both `db:backup` and `db:backups` (that would be very typo-prone), and I think what I have right now is consistent with some of our other naming conventions (list on the resource being listed — as opposed to the container —, other actions on the resource being acted on), but let me know if you disagree.

cc @fancyremarker 