### PR TITLE
Show git remote when creating app

### DIFF
--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -30,6 +30,7 @@ module Aptible
                 fail Thor::Error, app.errors.full_messages.first
               else
                 say "App #{handle} created!"
+                say "Git remote: #{app.git_repo}"
               end
             end
 


### PR DESCRIPTION
Expecting users to have to guess the git remote (environment handle
included and everything) isn't ideal.

cc @fancyremarker @wcpines (you might want to update the quickstarts once this is live)