### PR TITLE
Only report coverage in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,10 @@ require 'webmock/rspec'
 require 'simplecov'
 SimpleCov.start
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+if ENV['CI']
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 
 # Load shared spec files
 Dir["#{File.dirname(__FILE__)}/shared/**/*.rb"].each do |file|


### PR DESCRIPTION
cc @blakepettersson — I'm getting the following on each test run otherwise:

```
{"meta": {"status": 400}, "error": {"reason": "Please provide the repository token to upload reports via `-t :repository-token`", "context": null}}
````
