### PR TITLE
Ensure CLI can load without git on the PATH

### DIFF
--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -1,5 +1,9 @@
 require 'aptible/api'
-require 'git'
+
+# Avoid requiring the git gem upfront, since it'll fail to load if git isn't
+# available, whereas we're able to gracefully handle that by requiring the
+# --app and / or --environment flags.
+autoload :Git, 'git'
 
 module Aptible
   module CLI

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -1,5 +1,4 @@
 require 'aptible/api'
-require 'git'
 
 module Aptible
   module CLI

--- a/spec/aptible/cli/agent_spec.rb
+++ b/spec/aptible/cli/agent_spec.rb
@@ -107,4 +107,15 @@ describe Aptible::CLI::Agent do
       end
     end
   end
+
+  context 'load' do
+    it 'loads without git' do
+      mocks = File.expand_path('../../../mock', __FILE__)
+      bins =  File.expand_path('../../../../bin', __FILE__)
+      ClimateControl.modify PATH: [mocks, bins, ENV['PATH']].join(':') do
+        _, _, status = Open3.capture3('aptible version')
+        expect(status).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/mock/git
+++ b/spec/mock/git
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 1


### PR DESCRIPTION
In practice most customers will have git on their PATH, but it's
probably preferable not to fail loading the entire CLI just because git
is not available (especially considering we're able to handle that
gracefully).

cc @fancyremarker @blakepettersson 