### PR TITLE
Tunnel Helper: exit when port forwarding fails

### DIFF
--- a/spec/mock/ssh_mock.rb
+++ b/spec/mock/ssh_mock.rb
@@ -10,9 +10,12 @@ else
   puts 1234
 end
 
-# Log to stderr so we can collect in test
+# Log to SSH_MOCK_OUTFILE
+require 'json'
 
-$stderr.puts ARGV.size
-ARGV.each do |a|
-  $stderr.puts a
+File.open(ENV.fetch('SSH_MOCK_OUTFILE'), 'w') do |f|
+  f.write({
+    'argc' => ARGV.size,
+    'argv' => ARGV
+  }.to_json)
 end


### PR DESCRIPTION
As reported by Diego Argueta, the CLI does not exit when port forwarding
fails because something else is already listening on the port that was
chosen.

The impact of this problem can range from annoying (if another program
races us to open that port) to insecure (if another program is
intentionally hogging the port).

This fixes the issue by setting ExitOnForwardFailure=yes when launching
the tunnel, which makes the SSH client exit rather than fail silently.

In order to make this easy to troubleshoot, we also capture SSH's error
output (and remove the `-q` flag), and dump it as part of our exception
in case the tunnel fails to come up (which requires refactoring the
tests slightly to stop relying on capturing SSH's stderr rather, which
is probably for the best anyway as it makes them fail more promptly).

Fixes: https://aptible.zendesk.com/agent/tickets/6440


---

cc @fancyremarker @chasballew 