### PR TITLE
Add --simulate-oom restart flag

### DIFF
--- a/lib/aptible/cli/subcommands/restart.rb
+++ b/lib/aptible/cli/subcommands/restart.rb
@@ -8,10 +8,34 @@ module Aptible
             include Helpers::App
 
             desc 'restart', 'Restart all services associated with an app'
+            option :simulate_oom,
+                   type: :boolean,
+                   desc: 'Add this flag to simulate an OOM restart and test ' \
+                         "your app's response (not recommended on production " \
+                         'apps).'
+            option :force,
+                   type: :boolean,
+                   desc: 'Add this flag to use --simulate-oom in a ' \
+                         'production environment, which is not allowed by ' \
+                         'default.'
             app_options
             def restart
               app = ensure_app(options)
-              operation = app.create_operation!(type: 'restart')
+              type = 'restart'
+
+              if options[:simulate_oom]
+                type = 'captain_comeback_restart'
+
+                if app.account.type == 'production' && !options[:force]
+                  e = 'This operation is designed for test purposes only, ' \
+                      "but #{app.handle} is deployed in a production " \
+                      'environment. Are you sure you want to do this? If ' \
+                      'so, use the --force flag.'
+                  fail Thor::Error, e
+                end
+              end
+
+              operation = app.create_operation!(type: type)
               puts 'Restarting app...'
               attach_to_operation_logs(operation)
             end

--- a/spec/aptible/cli/subcommands/restart_spec.rb
+++ b/spec/aptible/cli/subcommands/restart_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  let(:app) { Fabricate(:app) }
+  let(:operation) { Fabricate(:operation, resource: app) }
+  before { allow(subject).to receive(:ensure_app).and_return(app) }
+
+  describe '#restart' do
+    it 'restarts the app' do
+      expect(app).to receive(:create_operation!).with(type: 'restart')
+        .and_return(operation)
+      expect(subject).to receive(:attach_to_operation_logs).with(operation)
+
+      subject.send('restart')
+    end
+
+    it 'does not require the --force flag for a regular restart' do
+      app.account.type = 'production'
+      expect(app).to receive(:create_operation!)
+      expect(subject).to receive(:attach_to_operation_logs)
+
+      subject.send('restart')
+    end
+
+    it 'uses captain_comeback_restart if --simulate-oom is passed' do
+      subject.options = { simulate_oom: true }
+      expect(app).to receive(:create_operation!)
+        .with(type: 'captain_comeback_restart')
+        .and_return(operation)
+      expect(subject).to receive(:attach_to_operation_logs).with(operation)
+
+      subject.send('restart')
+    end
+
+    it 'fails a CC restart if the --force flag is not passed for a prod app' do
+      subject.options = { simulate_oom: true }
+      app.account.type = 'production'
+      expect(app).not_to receive(:create_operation!)
+      expect(subject).not_to receive(:attach_to_operation_logs)
+
+      expect { subject.send('restart') }.to raise_error(/are you sure/i)
+    end
+
+    it 'creates a CC restart if the --force flag is passed for a prod app' do
+      subject.options = { simulate_oom: true, force: true }
+      app.account.type = 'production'
+      expect(app).to receive(:create_operation!)
+      expect(subject).to receive(:attach_to_operation_logs)
+
+      subject.send('restart')
+    end
+  end
+end


### PR DESCRIPTION
This allows users to test how their app reacts to an OOM restart on
Aptible.

See: https://github.com/aptible/sweetness/pull/639

--

cc @fancyremarker  @blakepettersson 