### PR TITLE
Make db:tunnel more windows-friendly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,11 @@ environment:
     - RUBY_VERSION: 21
 
 install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - set SSL_CERT_DIR=%PROGRAMFILES%\Git\mingw64\ssl\certs
+  - set SSL_CERT_FILE=%PROGRAMFILES%\Git\mingw64\ssl\cert.pem
+  # Override PATHEXT so our ssh bat file has a higher precedence.
+  - set PATHEXT=.BAT;.COM;.EXE;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+  - set PATH=C:\Ruby%RUBY_VERSION%-x64\bin;%PATH%
   - bundle config --local path vendor/bundle
   - bundle install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 1.0.{build}-{branch}
+
+environment:
+  matrix:
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle config --local path vendor/bundle
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - RUBY_VERSION: 22
     - RUBY_VERSION: 21
-    - RUBY_VERSION: 200
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,16 @@ version: 1.0.{build}-{branch}
 
 environment:
   matrix:
-    - RUBY_VERSION: 22
+    - RUBY_VERSION: 200
     - RUBY_VERSION: 21
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 23
 
 install:
+  # The SSL_CERT_* environment variables are here since otherwise calls to
+  # codecov.io wtill not work. These variables do have to be set in order for
+  # the gem to make calls to the Aptible API, since otherwise Ruby will fail
+  # with a certificate verification error.
   - set SSL_CERT_DIR=%PROGRAMFILES%\Git\mingw64\ssl\certs
   - set SSL_CERT_FILE=%PROGRAMFILES%\Git\mingw64\ssl\cert.pem
   # Override PATHEXT so our ssh bat file has a higher precedence.

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'git'
   spec.add_dependency 'term-ansicolor'
   spec.add_dependency 'chronic_duration', '~> 0.10.6'
+  spec.add_dependency 'win32-process' if Gem.win_platform?
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'rake'

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -28,6 +28,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'term-ansicolor'
   spec.add_dependency 'chronic_duration', '~> 0.10.6'
 
+  if RUBY_PLATFORM =~ /mswin|mingw/i
+    spec.add_dependency 'win32-process'
+    spec.add_development_dependency 'appveyor-worker'
+  end
+
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'rake'

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -27,12 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'git'
   spec.add_dependency 'term-ansicolor'
   spec.add_dependency 'chronic_duration', '~> 0.10.6'
-
-  if RUBY_PLATFORM =~ /mswin|mingw/i
-    spec.add_dependency 'win32-process'
-    # spec.add_development_dependency 'appveyor-worker'
-  end
-
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'rake'

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   if RUBY_PLATFORM =~ /mswin|mingw/i
     spec.add_dependency 'win32-process'
-    spec.add_development_dependency 'appveyor-worker'
+    # spec.add_development_dependency 'appveyor-worker'
   end
 
   spec.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/aptible/cli/helpers/tunnel.rb
+++ b/lib/aptible/cli/helpers/tunnel.rb
@@ -1,28 +1,30 @@
 require 'socket'
 require 'open3'
-require 'win32/process' if RUBY_PLATFORM =~ /mswin|mingw/i
 
 module Aptible
   module CLI
     module Helpers
+      # The :new_pgroup key specifies the CREATE_NEW_PROCESS_GROUP flag for
+      # CreateProcessW() in the Windows API. This is a Windows only option.
+      # true means the new process is the root process of the new process
+      # group.
+      # This flag is necessary for Process.kill(:SIGINT, pid) on the
+      # subprocess.
+      STOP_SIGNAL = if Gem.win_platform?
+                      :SIGINT
+                    else
+                      :SIGHUP
+                    end
+      SPAWN_OPTS =  if Gem.win_platform?
+                      { new_pgroup: true }
+                    else
+                      {}
+                    end
+
       class Tunnel
         def initialize(env, ssh_cmd)
           @env = env
           @ssh_cmd = ssh_cmd
-
-          # The :new_pgroup key specifies the CREATE_NEW_PROCESS_GROUP flag for
-          # CreateProcessW() in the Windows API. This is a Windows only option.
-          # true means the new process is the root process of the new process
-          # group.
-          # This flag is necessary for Process.kill(:SIGINT, pid) on the
-          # subprocess.
-          if RUBY_PLATFORM =~ /mswin|mingw/i
-            @stop_signal = :SIGINT
-            @windows_opts = { new_pgroup: true }
-          else
-            @stop_signal = :SIGHUP
-            @windows_opts = {}
-          end
         end
 
         def start(desired_port = 0)
@@ -53,7 +55,7 @@ module Aptible
           out_read, out_write = IO.pipe
           err_read, err_write = IO.pipe
 
-          @pid = Process.spawn(tunnel_env, *tunnel_cmd, @windows_opts
+          @pid = Process.spawn(tunnel_env, *tunnel_cmd, SPAWN_OPTS
             .merge(in: :close, out: out_write, err: err_write))
 
           # Wait for the tunnel to come up before returning. The other end
@@ -74,7 +76,7 @@ module Aptible
         def stop
           fail 'You must call #start before calling #stop' if @pid.nil?
           begin
-            Process.kill(@stop_signal, @pid)
+            Process.kill(STOP_SIGNAL, @pid)
           rescue Errno::ESRCH
             nil # Dear Rubocop: I know what I'm doing.
           end

--- a/lib/aptible/cli/helpers/tunnel.rb
+++ b/lib/aptible/cli/helpers/tunnel.rb
@@ -1,5 +1,6 @@
 require 'socket'
 require 'open3'
+require 'win32-process' if Gem.win_platform?
 
 module Aptible
   module CLI

--- a/spec/aptible/cli/agent_spec.rb
+++ b/spec/aptible/cli/agent_spec.rb
@@ -162,7 +162,8 @@ describe Aptible::CLI::Agent do
     it 'loads without git' do
       mocks = File.expand_path('../../../mock', __FILE__)
       bins =  File.expand_path('../../../../bin', __FILE__)
-      ClimateControl.modify PATH: [mocks, bins, ENV['PATH']].join(':') do
+      sep = File::PATH_SEPARATOR
+      ClimateControl.modify PATH: [mocks, bins, ENV['PATH']].join(sep) do
         _, _, status = Open3.capture3('aptible version')
         expect(status).to eq(0)
       end

--- a/spec/aptible/cli/helpers/git_remote_handle_strategy_spec.rb
+++ b/spec/aptible/cli/helpers/git_remote_handle_strategy_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Aptible::CLI::Helpers::App::GitRemoteHandleStrategy do
-  let!(:work_dir) { Dir.mktmpdir }
-  after { FileUtils.remove_entry work_dir }
-  around { |example| Dir.chdir(work_dir) { example.run } }
+  around do |example|
+    Dir.mktmpdir do |work_dir|
+      Dir.chdir(work_dir) { example.run }
+    end
+  end
 
   context 'with git repo' do
     before { `git init` }

--- a/spec/aptible/cli/helpers/tunnel_spec.rb
+++ b/spec/aptible/cli/helpers/tunnel_spec.rb
@@ -4,7 +4,7 @@ describe Aptible::CLI::Helpers::Tunnel do
   include_context 'mock ssh'
 
   it 'forwards traffic to the remote port given by the server (1234)' do
-    helper = described_class.new({}, ['ssh_mock.rb'])
+    helper = described_class.new({}, ['ssh'])
 
     helper.start(0)
     helper.stop
@@ -23,7 +23,7 @@ describe Aptible::CLI::Helpers::Tunnel do
   end
 
   it 'accepts a desired local port' do
-    helper = described_class.new({}, ['ssh_mock.rb'])
+    helper = described_class.new({}, ['ssh'])
     helper.start(5678)
     helper.stop
 
@@ -35,13 +35,13 @@ describe Aptible::CLI::Helpers::Tunnel do
   end
 
   it 'captures and displays port discovery errors' do
-    helper = described_class.new({ 'FAIL_PORT' => '1' }, ['ssh_mock.rb'])
+    helper = described_class.new({ 'FAIL_PORT' => '1' }, ['ssh'])
     expect { helper.start }
       .to raise_error(/Failed to request.*Something went wrong/m)
   end
 
   it 'captures and displays tunnel errors' do
-    helper = described_class.new({ 'FAIL_TUNNEL' => '1' }, ['ssh_mock.rb'])
+    helper = described_class.new({ 'FAIL_TUNNEL' => '1' }, ['ssh'])
     expect { helper.start(0) }
       .to raise_error(/Tunnel did not come up.*Something went wrong/m)
   end

--- a/spec/mock/ssh
+++ b/spec/mock/ssh
@@ -1,1 +1,0 @@
-ssh_mock.rb

--- a/spec/mock/ssh
+++ b/spec/mock/ssh
@@ -1,0 +1,1 @@
+ssh_mock.rb

--- a/spec/mock/ssh.bat
+++ b/spec/mock/ssh.bat
@@ -1,0 +1,2 @@
+@echo off
+ruby.exe %cd%\spec\mock\ssh_mock.rb %*

--- a/spec/shared/mock_ssh_context.rb
+++ b/spec/shared/mock_ssh_context.rb
@@ -9,7 +9,7 @@ shared_context 'mock ssh' do
   around do |example|
     mocks_path = File.expand_path('../../mock', __FILE__)
     env = {
-      PATH: "#{mocks_path}:#{ENV['PATH']}",
+      PATH: "#{mocks_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}",
       SSH_MOCK_OUTFILE: ssh_mock_outfile.path
     }
 


### PR DESCRIPTION
- Use win32-process gem to spawn and kill processes.
- `SIGHUP` (or unix signals for that matter) is not supported on
  windows - ruby wrapper supports the equivalent of `SIGINT` though, so
  use that.
- Since subprocess terminates immediately on windows, there's no need
  to wait when stopping tunnel
- Add `new_pgroup` flag, since that seems to be the only way to be able
  to `SIGINT` a subprocess. This flag is invalid on *nix, so we have to
  ensure it's only used on windows
- ~Add appveyor gem when testing on windows~
