### PR TITLE
db:tunnel: ignore Errno::ESRCH when kill'ing ssh

### DIFF
--- a/lib/aptible/cli/helpers/tunnel.rb
+++ b/lib/aptible/cli/helpers/tunnel.rb
@@ -58,12 +58,18 @@ module Aptible
 
         def stop
           fail 'You must call #start before calling #stop' if @pid.nil?
-          Process.kill('HUP', @pid)
+          begin
+            Process.kill('HUP', @pid)
+          rescue Errno::ESRCH
+            nil # Dear Rubocop: I know what I'm doing.
+          end
           wait
         end
 
         def wait
           Process.wait @pid
+        rescue Errno::ECHILD
+          nil
         end
 
         def port


### PR DESCRIPTION
On Linux, we can send SIGHUP to a dead process without issues, but on
Windows (including "Bash for Windows"), this happens to fail.

In practice, it doesn't really matter if this fails (since the intention
was to stop the process anyway), so we just ignore it.

This is particularly useful since we'll call `stop` if we get an
exception when running `ssh`, and if `stop` fails we'll never get to see
the original exception.

---

cc @blakepettersson 