### PR TITLE
Disable ControlMaster / ControlPath

### DIFF
--- a/lib/aptible/cli/helpers/ssh.rb
+++ b/lib/aptible/cli/helpers/ssh.rb
@@ -24,7 +24,9 @@ module Aptible
             '-o', 'TCPKeepAlive=yes',
             '-o', 'KeepAlive=yes',
             '-o', 'ServerAliveInterval=60',
-            '-o', "LogLevel=#{log_level}"
+            '-o', "LogLevel=#{log_level}",
+            '-o', 'ControlMaster=no',
+            '-o', 'ControlPath=none'
           ]
         end
       end


### PR DESCRIPTION
As noted in https://github.com/aptible/aptible-cli/issues/201, it looks
like SSH's ControlMaster doesn't respect a client's `SendEnv`
directives, which means a single connection can't be shared across
Aptible commands that require different environment variables (like
`aptible ssh` and `aptible db:tunnel`).

One option would be to set the `ControlPath` to something that depends
on the environment variables we plan to allow, which would let users
take advantage of functional AND faster tunnels, but for now the safer
option is probably to disable ControlMaster altogether (so that the
Aptible CLI does not set up a shared connection) and ControlPath (so
that the Aptible CLI dos not attempt to reuse a shared connection).

Fixes: #201 

---

cc @fancyremarker @blakepettersson 