### PR TITLE
Add `aptible certs` command

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -21,6 +21,7 @@ require_relative 'subcommands/rebuild'
 require_relative 'subcommands/restart'
 require_relative 'subcommands/ssh'
 require_relative 'subcommands/backup'
+require_relative 'subcommands/certs'
 
 module Aptible
   module CLI
@@ -38,6 +39,7 @@ module Aptible
       include Subcommands::Restart
       include Subcommands::SSH
       include Subcommands::Backup
+      include Subcommands::Certs
 
       # Forward return codes on failures.
       def self.exit_on_failure?

--- a/lib/aptible/cli/subcommands/certs.rb
+++ b/lib/aptible/cli/subcommands/certs.rb
@@ -1,0 +1,35 @@
+module Aptible
+  module CLI
+    module Subcommands
+      module Certs
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::Environment
+            include Helpers::Token
+
+            desc 'certs', 'List all certificates'
+            option :environment
+            def certs
+              scoped_environments(options).each do |env|
+                say "=== #{env.handle}"
+
+                env.certificates.each do |cert|
+                  cert_start = Date.parse(cert.not_before).iso8601
+                  cert_end = Date.parse(cert.not_after).iso8601
+
+                  # 123: *.example.com, COMODO, valid 2016-01-01 - 2016-01-01
+                  say "#{cert.id}: " \
+                  "'#{cert.common_name}', " \
+                    "#{cert.issuer_organization}, " \
+                    "valid #{cert_start} - #{cert_end}"
+                end
+
+                say ''
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/certs_spec.rb
+++ b/spec/aptible/cli/subcommands/certs_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  before { subject.stub(:ask) }
+  before { subject.stub(:save_token) }
+  before { subject.stub(:fetch_token) { double 'token' } }
+
+  let!(:foo_certs) { [Fabricate(:cert), Fabricate(:cert)] }
+  let!(:bar_certs) { [Fabricate(:cert)] }
+  let!(:foo_account) do
+    Fabricate(:account, certificates: foo_certs, handle: 'foo')
+  end
+  let!(:bar_account) do
+    Fabricate(:account, certificates: bar_certs, handle: 'bar')
+  end
+
+  describe '#certs' do
+    include_context 'with output'
+
+    before do
+      allow(Aptible::Api::Certificate).to receive(:all) do
+        [Fabricate(:cert)]
+      end
+      allow(subject).to receive(:options) { {} }
+      allow(Aptible::Api::Account).to receive(:all) do
+        [foo_account, bar_account]
+      end
+    end
+
+    it 'prints all certificates for all environments' do
+      subject.send('certs')
+
+      expect(output).to eq <<-eos
+=== foo
+#{foo_certs[0].id}: '*.example.com', Justice League, valid 2015-08-20 - 2017-08-20
+#{foo_certs[1].id}: '*.example.com', Justice League, valid 2015-08-20 - 2017-08-20
+
+=== bar
+#{bar_certs[0].id}: '*.example.com', Justice League, valid 2015-08-20 - 2017-08-20
+
+      eos
+    end
+
+    context 'with an environment specified' do
+      before do
+        allow(subject).to receive(:options) { { environment: 'foo' } }
+        expect(subject).to receive(:environment_from_handle)
+          .with('foo')
+          .and_return(foo_account)
+      end
+      it 'should print all certificates for environment' do
+        subject.send('certs')
+
+        expect(output).to eq <<-eos
+=== foo
+#{foo_certs[0].id}: '*.example.com', Justice League, valid 2015-08-20 - 2017-08-20
+#{foo_certs[1].id}: '*.example.com', Justice League, valid 2015-08-20 - 2017-08-20
+
+        eos
+      end
+    end
+  end
+end

--- a/spec/fabricators/cert_fabricator.rb
+++ b/spec/fabricators/cert_fabricator.rb
@@ -1,0 +1,9 @@
+class StubCert < OpenStruct; end
+
+Fabricator(:cert, from: :stub_cert) do
+  common_name '*.example.com'
+  issuer_organization 'Justice League'
+  not_before '2015-08-20T00:00:00.000Z'
+  not_after '2017-08-20T00:00:00.000Z'
+  id { rand(10000) }
+end

--- a/spec/shared/with_output.rb
+++ b/spec/shared/with_output.rb
@@ -1,0 +1,10 @@
+# Buffers `say` output strings so that you can assert the entire body of your
+# command's output, rather than having to assert it line-by-line.
+shared_context 'with output' do
+  let(:output) { '' }
+  before do
+    allow(subject).to receive(:say) do |said|
+      output << said + "\n"
+    end
+  end
+end


### PR DESCRIPTION
One of the aptible resources not yet supported by the cli is SSL
certificates.  This change adds a simple list command to display all
current certificates.

I somewhat arbitrarily went with the `aptible foos` convention used by
apps, domains, and config, over the `aptible foo:list` convention used
by backups and db.

The output looks like this:

```
=== environment_name
1234: '*.example.com', Issuer Name, valid 2015-08-20 - 2017-08-20
```

At some point we'll probably want to be able to reference certificates
in other commands (for example, when creating a new vhost), so we'll
need a unique identifier for the certificates exposed in this output.
Since certificates don't have a user-friendly handle, I used the
aptible-provided ID instead.
