### PR TITLE
db:clone: attach to operation logs

### DIFF
--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -47,7 +47,7 @@ module Aptible
 
         def clone_database(source, dest_handle)
           op = source.create_operation!(type: 'clone', handle: dest_handle)
-          poll_for_success(op)
+          attach_to_operation_logs(op)
 
           databases_from_handle(dest_handle, source.account).first
         end


### PR DESCRIPTION
This ensures we'll tell the user why if their clone operation fails.

--

Note: this will get end-to-end test coverage in aptible-integration, so considering we don't have any existing specs for `db:clone`, I'm not going to add any right now.

cc @fancyremarker @blakepettersson 