### PR TITLE
Cancel operations

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -21,6 +21,7 @@ require_relative 'subcommands/rebuild'
 require_relative 'subcommands/restart'
 require_relative 'subcommands/ssh'
 require_relative 'subcommands/backup'
+require_relative 'subcommands/operation'
 
 module Aptible
   module CLI
@@ -38,6 +39,7 @@ module Aptible
       include Subcommands::Restart
       include Subcommands::SSH
       include Subcommands::Backup
+      include Subcommands::Operation
 
       # Forward return codes on failures.
       def self.exit_on_failure?

--- a/lib/aptible/cli/helpers/operation.rb
+++ b/lib/aptible/cli/helpers/operation.rb
@@ -11,8 +11,8 @@ module Aptible
         def poll_for_success(operation)
           wait_for_completion operation
           return if operation.status == 'succeeded'
-          fail Thor::Error,
-               'Operation failed. Please contact support@aptible.com'
+
+          fail Thor::Error, "Operation ##{operation.id} failed."
         end
 
         def wait_for_completion(operation)

--- a/lib/aptible/cli/helpers/operation.rb
+++ b/lib/aptible/cli/helpers/operation.rb
@@ -40,6 +40,19 @@ module Aptible
           # the error message.
           poll_for_success(operation) unless success
         end
+
+        def cancel_operation(operation)
+          puts "Cancelling #{prettify_operation(operation)}..."
+          operation.update!(cancelled: true)
+        end
+
+        def prettify_operation(o)
+          bits = [o.status, o.type, "##{o.id}"]
+          if o.resource.respond_to?(:handle)
+            bits.concat ['on', o.resource.handle]
+          end
+          bits.join ' '
+        end
       end
     end
   end

--- a/lib/aptible/cli/subcommands/operation.rb
+++ b/lib/aptible/cli/subcommands/operation.rb
@@ -1,0 +1,23 @@
+module Aptible
+  module CLI
+    module Subcommands
+      module Operation
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::Token
+            include Helpers::Operation
+
+            desc 'operation:cancel OPERATION_ID', 'Cancel a running operation'
+            define_method 'operation:cancel' do |operation_id|
+              o = Aptible::Api::Operation.find(operation_id, token: fetch_token)
+              fail "Operation ##{operation_id} not found" if o.nil?
+
+              puts "Requesting cancellation on #{prettify_operation(o)}..."
+              o.update!(cancelled: true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aptible/cli/helpers/operation_spec.rb
+++ b/spec/aptible/cli/helpers/operation_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Helpers::Operation do
+  subject { Class.new.send(:include, described_class).new }
+
+  describe '#prettify_operation' do
+    it 'works for app operations' do
+      op = Fabricate(:operation, id: 123, type: 'deploy', status: 'running',
+                                 resource: Fabricate(:app, handle: 'myapp'))
+
+      expect(subject.prettify_operation(op))
+        .to eq('running deploy #123 on myapp')
+    end
+
+    it 'works for backup operations' do
+      op = Fabricate(:operation, id: 123, type: 'restore', status: 'queued',
+                                 resource: Fabricate(:backup))
+
+      expect(subject.prettify_operation(op))
+        .to eq('queued restore #123')
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/operation_spec.rb
+++ b/spec/aptible/cli/subcommands/operation_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  let(:token) { 'some-token' }
+  let(:operation) { Fabricate(:operation) }
+
+  before do
+    allow(subject).to receive(:fetch_token).and_return(token)
+    allow(subject).to receive(:say) { |m| messages << m }
+  end
+
+  describe '#operation:cancel' do
+    it 'fails if the operation cannot be found' do
+      expect(Aptible::Api::Operation).to receive(:find).with(1, token: token)
+        .and_return(nil)
+
+      expect { subject.send('operation:cancel', 1) }
+        .to raise_error('Operation #1 not found')
+    end
+
+    it 'sets the cancelled flag on the operation' do
+      expect(Aptible::Api::Operation).to receive(:find).with(1, token: token)
+        .and_return(operation)
+
+      expect(operation).to receive(:update!).with(cancelled: true)
+
+      subject.send('operation:cancel', 1)
+    end
+  end
+end


### PR DESCRIPTION
commit e792f687654d564358c891c19c22b39c3eb58854
Author: Thomas Orozco <thomas@orozco.fr>
Date:   Thu Dec 1 13:53:30 2016 +0100

    Indicate operation ID when operation failed
    
    There's a lot more detailed output coming out of Sweetness that explains
    what to do, it's probably not needed for the aptible CLI to layer on its
    own error message.

commit a3262998980b83d8d69cf93b45241ef74f69de53
Author: Thomas Orozco <thomas@orozco.fr>
Date:   Thu Dec 1 13:53:22 2016 +0100

    Add aptible operation:cancel OPERATION_ID
    
    This adds the ability to cancel an operation (more specifically: to
    request cancellation - only operations that support it will care for
    that flag).
    
    Ideally, I'd like this to eventually attach to the operation so you can
    see it complete (and to have a matching `aptible operation:attach`
    command), but this wouldn't be terribly useful right now since our
    operation logging mechanism does not support having multiple clients
    connected at the same time (this is perhaps something we'd fix
    indirectly by sending operation logs to a Log Drain, where we have all
    the infrastructure in place to deal with this already in tail drains).


---

cc @fancyremarker @blakepettersson 