### PR TITLE
Fix Thor warning

### DIFF
--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -22,7 +22,7 @@ module Aptible
 
             desc 'db:create HANDLE', 'Create a new database'
             option :type, default: 'postgresql'
-            option :size, default: 10
+            option :size, default: 10, type: :numeric
             option :environment
             define_method 'db:create' do |handle|
               environment = ensure_environment(options)


### PR DESCRIPTION
Silences:

```
Expected string default value for '--size'; got 10 (numeric)
```

See: https://github.com/aptible/pancake/pull/156

---

@fancyremarker, do you think we should include a `Gemfile.lock` in this repo to ensure the [omnibus-aptible-toolbelt](https://github.com/aptible/omnibus-aptible-toolbelt) always gets the same versions for its dependencies?