### PR TITLE
Upgrade aptible-api to 0.9.15

### DIFF
--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-api', '~> 0.9.14'
+  spec.add_dependency 'aptible-api', '~> 0.9.15'
   spec.add_dependency 'aptible-auth', '~> 0.11.8'
   spec.add_dependency 'aptible-resource', '~> 0.3.6'
   spec.add_dependency 'thor', '~> 0.19.1'


### PR DESCRIPTION
This gives us https://github.com/aptible/aptible-api-ruby/pull/76, which
ensures that clients can connect to the SSH Portal even if they have too
many unacceptable keys in their SSH Agent keyring.