### PR TITLE
APTIBLE_SSH_VERBOSE -> APTIBLE_SSH_DEBUG

### DIFF
--- a/lib/aptible/cli/helpers/ssh.rb
+++ b/lib/aptible/cli/helpers/ssh.rb
@@ -73,7 +73,7 @@ module Aptible
         end
 
         def common_ssh_args
-          log_level = ENV['APTIBLE_SSH_VERBOSE'] ? 'VERBOSE' : 'ERROR'
+          log_level = ENV['APTIBLE_SSH_DEBUG'] ? 'DEBUG3' : 'ERROR'
 
           [
             '-o', 'StrictHostKeyChecking=no',


### PR DESCRIPTION
The verbose log level isn't particularly useful when trying to
troubleshoot connection issues, so let's go all the way to DEBUG3 when
APTIBLE_SSH_DEBUG is set

---

cc @fancyremarker 