### PR TITLE
Fix Windows exit tunnel

### DIFF
--- a/lib/aptible/cli/helpers/tunnel.rb
+++ b/lib/aptible/cli/helpers/tunnel.rb
@@ -5,17 +5,17 @@ require 'win32-process' if Gem.win_platform?
 module Aptible
   module CLI
     module Helpers
-      # The :new_pgroup key specifies the CREATE_NEW_PROCESS_GROUP flag for
-      # CreateProcessW() in the Windows API. This is a Windows only option.
-      # true means the new process is the root process of the new process
-      # group.
-      # This flag is necessary for Process.kill(:SIGINT, pid) on the
-      # subprocess.
       STOP_SIGNAL = if Gem.win_platform?
-                      :SIGINT
+                      :SIGBRK
                     else
                       :SIGHUP
                     end
+
+      # The :new_pgroup key specifies the CREATE_NEW_PROCESS_GROUP flag for
+      # CreateProcessW() in the Windows API. This is a Windows only option.
+      # true means the new process is the root process of the new process
+      # group. This flag is necessary to be able to signal the subprocess on
+      # Windows.
       SPAWN_OPTS =  if Gem.win_platform?
                       { new_pgroup: true }
                     else


### PR DESCRIPTION
It looks like we need to apply more force when shutting down OpenSSH on
Windows, at least when using the Windows fork
(https://github.com/PowerShell/Win32-OpenSSH /
https://github.com/PowerShell/openssh-portable).

Using `SIGINT`, it looks like the OpenSSH process doesn't do anything.

Unfortunately, it appears this causes OpenSSH to not cleanly disconnect
from the server.

This is not ideal, but it's probably acceptable for now since we'll stop
sending keep-alives and the connection should end up shutting down on
the server-side reasonably quickly (about 2 minute later).

---

This should fix part of the issue reported in https://github.com/aptible/aptible-cli/issues/212

cc @fancyremarker 