### PR TITLE
Add support for tunnelling to database credentials

### DIFF
--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-api', '~> 0.9.16'
+  spec.add_dependency 'aptible-api', '~> 0.9.20'
   spec.add_dependency 'aptible-auth', '~> 0.11.12'
   spec.add_dependency 'aptible-resource', '~> 0.3.6'
   spec.add_dependency 'thor', '~> 0.19.1'
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chronic_duration', '~> 0.10.6'
   spec.add_dependency 'win32-process' if Gem.win_platform?
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
+  spec.add_development_dependency 'aptible-tasks', '~> 0.5.8'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'climate_control'
+  spec.add_development_dependency 'climate_control', '= 0.0.3'
   spec.add_development_dependency 'fabrication', '~> 2.15.2'
 end

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -55,14 +55,14 @@ module Aptible
 
         # Creates a local tunnel and yields the helper
 
-        def with_local_tunnel(database, port = 0)
-          op = database.create_operation!(type: 'tunnel', status: 'succeeded')
+        def with_local_tunnel(credential, port = 0)
+          op = credential.create_operation!(type: 'tunnel', status: 'succeeded')
 
-          with_ssh_cmd(op) do |base_ssh_cmd, credential|
+          with_ssh_cmd(op) do |base_ssh_cmd, ssh_credential|
             ssh_cmd = base_ssh_cmd + ['-o', 'SendEnv=ACCESS_TOKEN']
             ssh_env = { 'ACCESS_TOKEN' => fetch_token }
 
-            socket_path = credential.ssh_port_forward_socket
+            socket_path = ssh_credential.ssh_port_forward_socket
             tunnel_helper = Helpers::Tunnel.new(ssh_env, ssh_cmd, socket_path)
 
             tunnel_helper.start(port)
@@ -78,19 +78,37 @@ module Aptible
             raise Thor::Error, 'This command only works for PostgreSQL'
           end
 
-          with_local_tunnel(database) do |tunnel_helper|
-            auth = "aptible:#{database.passphrase}"
-            host = "localhost.aptible.in:#{tunnel_helper.port}"
-            yield "postgresql://#{auth}@#{host}/db"
+          credential = find_tunnel_credential(database)
+
+          with_local_tunnel(credential) do |tunnel_helper|
+            yield local_url(credential, tunnel_helper.port)
           end
         end
 
-        def local_url(database, local_port)
-          remote_url = database.connection_url
+        def local_url(credential, local_port)
+          remote_url = credential.connection_url
           uri = URI.parse(remote_url)
 
           "#{uri.scheme}://#{uri.user}:#{uri.password}@" \
           "localhost.aptible.in:#{local_port}#{uri.path}"
+        end
+
+        def find_tunnel_credential(database, type = nil)
+          unless database.provisioned?
+            raise Thor::Error, "Database #{database.handle} is not provisioned"
+          end
+
+          finder = proc { |c| c.default }
+          finder = proc { |c| c.type == type } if type
+          credential = database.database_credentials.find(&finder)
+
+          return credential if credential
+
+          valid = database.database_credentials.map(&:type).join(', ')
+
+          err = 'No default credential for database'
+          err = "No credential with type #{type} for database" if type
+          raise Thor::Error, "#{err}, valid credential types: #{valid}"
         end
       end
     end

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -104,7 +104,17 @@ module Aptible
 
           return credential if credential
 
-          valid = database.database_credentials.map(&:type).join(', ')
+          types = database.database_credentials.map(&:type)
+
+          # On v1, we fallback to the DB. We make sure to make --type work, to
+          # avoid a confusing experience for customers.
+          if database.account.stack.version == 'v1'
+            types << database.type
+            types.uniq!
+            return database if type.nil? || type == database.type
+          end
+
+          valid = types.join(', ')
 
           err = 'No default credential for database'
           err = "No credential with type #{type} for database" if type

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -82,9 +82,12 @@ module Aptible
                   :green
 
               if options[:type].nil?
-                types = database.database_credentials.map(&:type).join(', ')
-                say 'Use --type TYPE to specify a tunnel type', :green
-                say "Valid types for #{database.handle}: #{types}", :green
+                types = database.database_credentials.map(&:type)
+                unless types.empty?
+                  valid = types.join(', ')
+                  say 'Use --type TYPE to specify a tunnel type', :green
+                  say "Valid types for #{database.handle}: #{valid}", :green
+                end
               end
 
               with_local_tunnel(credential, desired_port) do |tunnel_helper|

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -20,18 +20,78 @@ describe Aptible::CLI::Agent do
       end.to raise_error("Could not find database #{handle}")
     end
 
-    it 'should print a message about how to connect' do
-      allow(Aptible::Api::Database).to receive(:all) { [database] }
-      local_url = 'postgresql://aptible:password@localhost.aptible.in:4242/db'
+    context 'valid database' do
+      before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
 
-      expect(subject).to receive(:with_local_tunnel).with(database, 0)
-        .and_yield(socat_helper)
-      expect(subject).to receive(:say).with('Creating tunnel...', :green)
-      expect(subject).to receive(:say).with("Connect at #{local_url}", :green)
+      it 'prints a message explaining how to connect' do
+        cred = Fabricate(:database_credential, default: true, type: 'foo',
+                                               database: database)
 
-      # db:tunnel should also explain each component of the URL:
-      expect(subject).to receive(:say).exactly(7).times
-      subject.send('db:tunnel', handle)
+        expect(subject).to receive(:with_local_tunnel).with(cred, 0)
+          .and_yield(socat_helper)
+
+        expect(subject).to receive(:say)
+          .with('Creating foo tunnel to foobar...', :green)
+
+        local_url = 'postgresql://aptible:password@localhost.aptible.in:4242/db'
+        expect(subject).to receive(:say)
+          .with("Connect at #{local_url}", :green)
+
+        # db:tunnel should also explain each component of the URL and suggest
+        # the --type argument:
+        expect(subject).to receive(:say).exactly(9).times
+        subject.send('db:tunnel', handle)
+      end
+
+      it 'defaults to a default credential' do
+        ok = Fabricate(:database_credential, default: true, database: database)
+        Fabricate(:database_credential, database: database, type: 'foo')
+        Fabricate(:database_credential, database: database, type: 'bar')
+
+        messages = []
+        allow(subject).to receive(:say) { |m, *| messages << m }
+        expect(subject).to receive(:with_local_tunnel).with(ok, 0)
+
+        subject.send('db:tunnel', handle)
+
+        expect(messages.grep(/use --type type/im)).not_to be_empty
+        expect(messages.grep(/valid types.*foo.*bar/im)).not_to be_empty
+      end
+
+      it 'supports --type' do
+        subject.options = { type: 'foo' }
+
+        Fabricate(:database_credential, default: true, database: database)
+        ok = Fabricate(:database_credential, type: 'foo', database: database)
+        Fabricate(:database_credential, type: 'bar', database: database)
+
+        allow(subject).to receive(:say)
+        expect(subject).to receive(:with_local_tunnel).with(ok, 0)
+        subject.send('db:tunnel', handle)
+      end
+
+      it 'fails when there is no default database credential nor type' do
+        Fabricate(:database_credential, default: false, database: database)
+
+        expect { subject.send('db:tunnel', handle) }
+          .to raise_error(/no default credential/im)
+      end
+
+      it 'fails when the type is incorrect' do
+        subject.options = { type: 'bar' }
+
+        Fabricate(:database_credential, type: 'foo', database: database)
+
+        expect { subject.send('db:tunnel', handle) }
+          .to raise_error(/no credential with type bar/im)
+      end
+
+      it 'fails when the database is not provisioned' do
+        database.stub(status: 'pending')
+
+        expect { subject.send('db:tunnel', handle) }
+          .to raise_error(/foobar is not provisioned/im)
+      end
     end
   end
 

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -4,6 +4,7 @@ Fabricator(:account, from: :stub_account) do
   bastion_host 'localhost'
   dumptruck_port 1234
   handle 'aptible'
+  stack
 
   apps { [] }
   databases { [] }

--- a/spec/fabricators/database_credential_fabricator.rb
+++ b/spec/fabricators/database_credential_fabricator.rb
@@ -1,0 +1,11 @@
+class StubDatabaseCredential < OpenStruct; end
+
+Fabricator(:database_credential, from: :stub_database_credential) do
+  database
+
+  default false
+  type 'postgresql'
+  connection_url 'postgresql://aptible:password@10.252.1.125:49158/db'
+
+  after_create { |credential| database.database_credentials << credential }
+end

--- a/spec/fabricators/database_fabricator.rb
+++ b/spec/fabricators/database_fabricator.rb
@@ -1,4 +1,8 @@
-class StubDatabase < OpenStruct; end
+class StubDatabase < OpenStruct
+  def provisioned?
+    status == 'provisioned'
+  end
+end
 
 Fabricator(:database, from: :stub_database) do
   type 'postgresql'
@@ -6,10 +10,12 @@ Fabricator(:database, from: :stub_database) do
     Fabricate.sequence(:database) { |i| "#{attrs[:type]}-#{i}" }
   end
   passphrase 'password'
+  status 'provisioned'
   connection_url 'postgresql://aptible:password@10.252.1.125:49158/db'
   account
 
   backups { [] }
+  database_credentials { [] }
 
   after_create { |database| database.account.databases << database }
 end

--- a/spec/fabricators/stack_fabricator.rb
+++ b/spec/fabricators/stack_fabricator.rb
@@ -1,0 +1,9 @@
+class StubStack < OpenStruct; end
+
+Fabricator(:stack, from: :stub_stack) do
+  name 'foo'
+  version 'v2'
+
+  apps { [] }
+  databases { [] }
+end


### PR DESCRIPTION
This adds a --type option to `aptible db:tunnel`, which lets users
select a particular database credential (as opposed to just a database)
to connect to, which enables e.g. forwarding the RabbitMQ management UI.

---

cc @fancyremarker 

See: https://github.com/aptible/api.aptible.com/pull/481