### PR TITLE
aptible ssh: Correct TTY handling

### DIFF
--- a/spec/aptible/cli/subcommands/ssh_spec.rb
+++ b/spec/aptible/cli/subcommands/ssh_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  describe '#ssh' do
+    let(:app) { Fabricate(:app) }
+    let(:operation) { double('operation') }
+
+    context 'TTY control' do
+      before do
+        expect(subject).to receive(:ensure_app).and_return(app)
+        expect(subject).to receive(:fetch_token).and_return('some token')
+
+        expect(app).to receive(:create_operation!).with(
+          type: 'execute', command: '/bin/bash', status: 'succeeded'
+        ).and_return(operation)
+      end
+
+      it 'allocates a TTY if STDIN and STDOUT are TTYs' do
+        allow(STDIN).to receive(:tty?).and_return(true)
+        allow(STDOUT).to receive(:tty?).and_return(true)
+
+        expect(subject).to receive(:connect_to_ssh_portal).with(
+          operation, '-o', 'SendEnv=ACCESS_TOKEN', '-t'
+        )
+        subject.ssh
+      end
+
+      it 'allocates a TTY even if STDERR is redirected ' do
+        allow(STDIN).to receive(:tty?).and_return(true)
+        allow(STDOUT).to receive(:tty?).and_return(true)
+        allow(STDERR).to receive(:tty?).and_return(false)
+
+        expect(subject).to receive(:connect_to_ssh_portal).with(
+          operation, '-o', 'SendEnv=ACCESS_TOKEN', '-t'
+        )
+        subject.ssh
+      end
+
+      it 'does not allocate TTY if STDIN is redirected' do
+        allow(STDIN).to receive(:tty?).and_return(false)
+        allow(STDOUT).to receive(:tty?).and_return(true)
+
+        expect(subject).to receive(:connect_to_ssh_portal).with(
+          operation, '-o', 'SendEnv=ACCESS_TOKEN', '-T'
+        )
+        subject.ssh
+      end
+
+      it 'does not allocate TTY if STDOUT is redirected' do
+        allow(STDIN).to receive(:tty?).and_return(true)
+        allow(STDOUT).to receive(:tty?).and_return(false)
+
+        expect(subject).to receive(:connect_to_ssh_portal).with(
+          operation, '-o', 'SendEnv=ACCESS_TOKEN', '-T'
+        )
+        subject.ssh
+      end
+
+      it 'allocates a TTY if forced' do
+        subject.options = { force_tty: true }
+
+        allow(STDIN).to receive(:tty?).and_return(false)
+        allow(STDOUT).to receive(:tty?).and_return(false)
+
+        expect(subject).to receive(:connect_to_ssh_portal).with(
+          operation, '-o', 'SendEnv=ACCESS_TOKEN', '-tt'
+        )
+        subject.ssh
+      end
+    end
+  end
+end


### PR DESCRIPTION
SSH's default behavior is as follows:

- If a TTY is forced, one is allocated.
- If there is no command, then a TTY is allocated.
- If no-TTY is forced, then none is allocated.
- No TTY is allocated if stdin isn't a TTY.

Unfortunately, in our case, this breaks, because we use a
forced-command, so we don't *ever* send a command, which causes SSH to
*always* allocate TTY, which causes a variety of problems, not least of
which is that stdout and stderr end up merged.

Now, it's pretty common for Aptible users to run commands in their
container with the intention of using a TTY (by e.g. running `aptible
ssh bash`), so we use a slightly different heuristic from SSH: we
allocate TTY iif there's no input or output redirection going on.

End users can always override this behavior with the --force-tty option.

---

cc @fancyremarker 