### PR TITLE
Tunnel Helper: Force-kill after 5 seconds

### DIFF
--- a/spec/mock/ssh_mock.rb
+++ b/spec/mock/ssh_mock.rb
@@ -6,6 +6,7 @@ raise 'Something went wrong!' if ENV['FAIL_TUNNEL']
 # Log arguments to SSH_MOCK_OUTFILE
 File.open(ENV.fetch('SSH_MOCK_OUTFILE'), 'w') do |f|
   f.write({
+    'pid' => $PID,
     'argc' => ARGV.size,
     'argv' => ARGV,
     'env' => ENV.to_hash

--- a/spec/shared/mock_ssh_context.rb
+++ b/spec/shared/mock_ssh_context.rb
@@ -16,6 +16,12 @@ shared_context 'mock ssh' do
     ClimateControl.modify(env) { example.run }
   end
 
+  def read_mock_pid
+    File.open(ssh_mock_outfile) do |f|
+      return JSON.load(f.read).fetch('pid')
+    end
+  end
+
   def read_mock_argv
     File.open(ssh_mock_outfile) do |f|
       return JSON.load(f.read).fetch('argv')


### PR DESCRIPTION
This adds support for force-killing the SSH Helper after 5 seconds if it
doesn't exist immediately. This isn't required when running actual
OpenSSH, but when running the mock ssh.bat helper we use in tests, it
usually is (because sending `SIGBRK`, or even `SIGINT` to a console
doesn't always reliably terminate it).

NOTE: I'm leaving around a couple debug helpers in specs if needed in
the future.

---

cc @fancyremarker 