### PR TITLE
Add a db:reload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,31 +28,36 @@ From `aptible help`:
 
 ```
 Commands:
-  aptible apps                        # List all applications
-  aptible apps:create HANDLE          # Create a new application
-  aptible apps:deprovision            # Deprovision an app
-  aptible apps:scale TYPE NUMBER      # Scale app to NUMBER of instances
-  aptible config                      # Print an app's current configuration
-  aptible config:add                  # Add an ENV variable to an app
-  aptible config:rm                   # Remove an ENV variable from an app
-  aptible config:set                  # Alias for config:add
-  aptible config:unset                # Alias for config:rm
-  aptible db:clone SOURCE DEST        # Clone a database to create a new one
-  aptible db:create HANDLE            # Create a new database
-  aptible db:deprovision HANDLE       # Deprovision a database
-  aptible db:dump HANDLE              # Dump a remote database to file
-  aptible db:execute HANDLE SQL_FILE  # Executes sql against a database
-  aptible db:list                     # List all databases
-  aptible db:tunnel HANDLE            # Create a local tunnel to a database
-  aptible domains                     # Print an app's current virtual domains
-  aptible help [COMMAND]              # Describe available commands or one specific command
-  aptible login                       # Log in to Aptible
-  aptible logs                        # Follows logs from a running app
-  aptible ps                          # Display running processes for an app - DEPRECATED
-  aptible rebuild                     # Rebuild an app, and restart its services
-  aptible restart                     # Restart all services associated with an app
-  aptible ssh [COMMAND]               # Run a command against an app
-  aptible version                     # Print Aptible CLI version
+  aptible apps                                               # List all applications
+  aptible apps:create HANDLE                                 # Create a new application
+  aptible apps:deprovision                                   # Deprovision an app
+  aptible apps:scale TYPE NUMBER                             # Scale app to NUMBER of instances
+  aptible backup:list DB_HANDLE                              # List backups for a database
+  aptible backup:restore [--handle HANDLE] [--size SIZE_GB]  # Restore a backup
+  aptible config                                             # Print an app's current configuration
+  aptible config:add                                         # Add an ENV variable to an app
+  aptible config:rm                                          # Remove an ENV variable from an app
+  aptible config:set                                         # Alias for config:add
+  aptible config:unset                                       # Alias for config:rm
+  aptible db:backup HANDLE                                   # Backup a database
+  aptible db:clone SOURCE DEST                               # Clone a database to create a new one
+  aptible db:create HANDLE                                   # Create a new database
+  aptible db:deprovision HANDLE                              # Deprovision a database
+  aptible db:dump HANDLE                                     # Dump a remote database to file
+  aptible db:execute HANDLE SQL_FILE                         # Executes sql against a database
+  aptible db:list                                            # List all databases
+  aptible db:reload HANDLE                                   # Reload a database
+  aptible db:tunnel HANDLE                                   # Create a local tunnel to a database
+  aptible domains                                            # Print an app's current virtual domains
+  aptible help [COMMAND]                                     # Describe available commands or one specific command
+  aptible login                                              # Log in to Aptible
+  aptible logs                                               # Follows logs from a running app or database
+  aptible operation:cancel OPERATION_ID                      # Cancel a running operation
+  aptible ps                                                 # Display running processes for an app - DEPRECATED
+  aptible rebuild                                            # Rebuild an app, and restart its services
+  aptible restart                                            # Restart all services associated with an app
+  aptible ssh [COMMAND]                                      # Run a command against an app
+  aptible version                                            # Print Aptible CLI version
 ```
 
 ## Contributing

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -129,6 +129,15 @@ module Aptible
               op = database.create_operation!(type: 'backup')
               attach_to_operation_logs(op)
             end
+
+            desc 'db:reload HANDLE', 'Reload a database'
+            option :environment
+            define_method 'db:reload' do |handle|
+              database = ensure_database(options.merge(db: handle))
+              say "Reloading #{database.handle}..."
+              op = database.create_operation!(type: 'reload')
+              attach_to_operation_logs(op)
+            end
           end
         end
       end

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -199,7 +199,8 @@ describe Aptible::CLI::Agent do
     let(:op) { Fabricate(:operation) }
 
     it 'allows creating a new backup' do
-      expect(database).to receive(:create_operation!).and_return(op)
+      expect(database).to receive(:create_operation!)
+        .with(type: 'backup').and_return(op)
       expect(subject).to receive(:say).with('Backing up foobar...')
       expect(subject).to receive(:attach_to_operation_logs).with(op)
 
@@ -208,6 +209,27 @@ describe Aptible::CLI::Agent do
 
     it 'fails if the DB is not found' do
       expect { subject.send('db:backup', 'nope') }
+        .to raise_error(Thor::Error, 'Could not find database nope')
+    end
+  end
+
+  describe '#db:reload' do
+    before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
+    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
+
+    let(:op) { Fabricate(:operation) }
+
+    it 'allows reloading a database' do
+      expect(database).to receive(:create_operation!)
+        .with(type: 'reload').and_return(op)
+      expect(subject).to receive(:say).with('Reloading foobar...')
+      expect(subject).to receive(:attach_to_operation_logs).with(op)
+
+      subject.send('db:reload', handle)
+    end
+
+    it 'fails if the DB is not found' do
+      expect { subject.send('db:reload', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
   end


### PR DESCRIPTION
This adds a db:reload command, which recreates a DB container in-place
(same instance, same mountpoint).

The implementation is very similar to db:backup and I suspect we may
eventually want to merge the two, but considering there were a couple
subtle differences (the log message), I opted to not do so here.

---

cc @fancyremarker 