### PR TITLE
Add command: aptible inspect URL

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 require 'aptible/auth'
 require 'thor'
 require 'json'
@@ -22,6 +24,7 @@ require_relative 'subcommands/restart'
 require_relative 'subcommands/ssh'
 require_relative 'subcommands/backup'
 require_relative 'subcommands/operation'
+require_relative 'subcommands/inspect'
 
 module Aptible
   module CLI
@@ -41,6 +44,7 @@ module Aptible
       include Subcommands::SSH
       include Subcommands::Backup
       include Subcommands::Operation
+      include Subcommands::Inspect
 
       # Forward return codes on failures.
       def self.exit_on_failure?

--- a/lib/aptible/cli/subcommands/inspect.rb
+++ b/lib/aptible/cli/subcommands/inspect.rb
@@ -1,0 +1,51 @@
+module Aptible
+  module CLI
+    module Subcommands
+      module Inspect
+        class InspectResourceCommand < Thor::HiddenCommand
+          def run(instance, args = [])
+            instance.inspect_resource(*args)
+          end
+        end
+
+        def inspect_resource(raw)
+          begin
+            uri = URI(raw)
+          rescue URI::InvalidURIError
+            raise Thor::Error, "Invalid URI: #{raw}"
+          end
+
+          if uri.scheme != 'https'
+            raise "Invalid scheme: #{uri.scheme} (use https)"
+          end
+
+          apis = [Aptible::Auth, Aptible::Api, Aptible::Billing]
+
+          api = apis.find do |klass|
+            uri.host == URI(klass.configuration.root_url).host
+          end
+
+          if api.nil?
+            hosts = apis.map(&:configuration).map(&:root_url).map do |u|
+              URI(u).host
+            end
+            m = "Invalid API: #{uri.host} (valid APIs: #{hosts.join(', ')})"
+            raise Thor::Error, m
+          end
+
+          res = api::Resource.new(token: fetch_token).find_by_url(uri.to_s)
+          puts JSON.pretty_generate(res.body)
+        end
+
+        def self.included(thor)
+          # We have to manually register a command here since we can't override
+          # the inspect method!
+          desc = 'Inspect a resource as JSON by URL'
+          thor.commands['inspect'] = InspectResourceCommand.new(
+            :inspect, desc, desc, 'inspect URL'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/inspect_spec.rb
+++ b/spec/aptible/cli/subcommands/inspect_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  describe '#inspect_resource' do
+    let(:token) { 'foo token' }
+    before { allow(subject).to receive(:fetch_token).and_return(token) }
+
+    it 'should fail if the URI is invalid' do
+      expect { subject.inspect_resource('^^') }
+        .to raise_error(/invalid uri/im)
+    end
+
+    it 'should fail if the URI is not for a valid host' do
+      expect { subject.inspect_resource('https://foo.com') }
+        .to raise_error(/invalid api/im)
+    end
+
+    it 'should fail if the scheme is invalid' do
+      # Not necessarily a feature per-se, but the URI will be parsed improperly
+      # if we don't have a scheme.
+      expect { subject.inspect_resource('api.aptible.com') }
+        .to raise_error(/invalid scheme/im)
+    end
+
+    it 'should succeed if the URI is complete' do
+      api = double('api')
+      expect(Aptible::Api::Resource).to receive(:new).with(token: token)
+        .and_return(api)
+
+      res = double('resource', body: { foo: 'bar' })
+      expect(api).to receive(:find_by_url).with('https://api.aptible.com/foo')
+        .and_return(res)
+
+      expect(subject).to receive(:puts) do |body|
+        expect(JSON.parse(body)).to eq('foo' => 'bar')
+      end
+
+      subject.inspect_resource('https://api.aptible.com/foo')
+    end
+  end
+end


### PR DESCRIPTION
The goal here is to provide a way for users to access resources exposed
by the API. This command is hidden since our API is not stable.

@fancyremarker I occasionally find myself reaching for a command line this one, and it could be useful for cases where a customer needs to programmatically access one or two fields in an API that's reasonably stable... but obviously it might be a little dangerous to make this an official command before we're able to make API stability guarantees. Let me know what you think.