### PR TITLE
Explain tunnel timeouts

### DIFF
--- a/spec/aptible/cli/helpers/tunnel_spec.rb
+++ b/spec/aptible/cli/helpers/tunnel_spec.rb
@@ -30,8 +30,21 @@ describe Aptible::CLI::Helpers::Tunnel do
     expect(mock_argv.shift).to eq('5678:/some.sock')
   end
 
+  it 'provides the port it picked' do
+    helper = described_class.new({}, ['ssh'], '/some.sock')
+    helper.start
+    port = helper.port
+    helper.stop
+
+    mock_argv = read_mock_argv
+    expect(mock_argv.size).to eq(4)
+
+    expect(mock_argv.shift).to eq('-L')
+    expect(mock_argv.shift).to eq("#{port}:/some.sock")
+  end
+
   it 'captures and displays tunnel errors' do
-    helper = described_class.new({ 'FAIL_TUNNEL' => '1' }, ['ssh'],
+    helper = described_class.new({ 'SSH_MOCK_FAIL_TUNNEL' => '1' }, ['ssh'],
                                  '/some.sock')
 
     expect { helper.start(0) }
@@ -46,5 +59,29 @@ describe Aptible::CLI::Helpers::Tunnel do
   it 'should fail if #stop is called before #start' do
     socat = described_class.new({}, [], '/some.sock')
     expect { socat.stop }.to raise_error(/You must call #start/)
+  end
+
+  it 'understands an exit status of 0' do
+    helper = described_class.new(
+      { 'SSH_MOCK_EXITCODE' => '0' }, ['ssh'], '/some.sock'
+    )
+    helper.start
+    helper.wait
+  end
+
+  it 'understands an exit status of 1' do
+    helper = described_class.new(
+      { 'SSH_MOCK_EXITCODE' => '1' }, ['ssh'], '/some.sock'
+    )
+    helper.start
+    expect { helper.wait }.to raise_error(/tunnel crashed/im)
+  end
+
+  it 'understands an exit status of 124' do
+    helper = described_class.new(
+      { 'SSH_MOCK_EXITCODE' => '124' }, ['ssh'], '/some.sock'
+    )
+    helper.start
+    expect { helper.wait }.to raise_error(/tunnel timed out/im)
   end
 end

--- a/spec/mock/ssh_mock.rb
+++ b/spec/mock/ssh_mock.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'json'
 
-raise 'Something went wrong!' if ENV['FAIL_TUNNEL']
+raise 'Something went wrong!' if ENV['SSH_MOCK_FAIL_TUNNEL']
 
 # Log arguments to SSH_MOCK_OUTFILE
 File.open(ENV.fetch('SSH_MOCK_OUTFILE'), 'w') do |f|
@@ -14,3 +14,5 @@ File.open(ENV.fetch('SSH_MOCK_OUTFILE'), 'w') do |f|
 end
 
 puts 'TUNNEL READY'
+
+exit Integer(ENV.fetch('SSH_MOCK_EXITCODE', 0))


### PR DESCRIPTION
We'll use exitcode 124 to indicate a timeout.

See: https://github.com/aptible/dynamic-uno/pull/12

cc @fancyremarker