### PR TITLE
Pin Rack to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'pry', github: 'fancyremarker/pry', branch: 'aptible'
 gem 'activesupport', '~> 4.0'
+gem 'rack', '~> 1.0'
 
 group :test do
   gem 'webmock'


### PR DESCRIPTION
2.x doesn't install on some versions of Ruby we test against, so we can
add this to our Gemfile like we did with ActiveSupport in order to
support those (the CLI works with them either way, though).