### PR TITLE
New apps:scale option format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,36 +28,36 @@ From `aptible help`:
 
 ```
 Commands:
-  aptible apps                                               # List all applications
-  aptible apps:create HANDLE                                 # Create a new application
-  aptible apps:deprovision                                   # Deprovision an app
-  aptible apps:scale TYPE NUMBER                             # Scale app to NUMBER of instances
-  aptible backup:list DB_HANDLE                              # List backups for a database
-  aptible backup:restore [--handle HANDLE] [--size SIZE_GB]  # Restore a backup
-  aptible config                                             # Print an app's current configuration
-  aptible config:add                                         # Add an ENV variable to an app
-  aptible config:rm                                          # Remove an ENV variable from an app
-  aptible config:set                                         # Alias for config:add
-  aptible config:unset                                       # Alias for config:rm
-  aptible db:backup HANDLE                                   # Backup a database
-  aptible db:clone SOURCE DEST                               # Clone a database to create a new one
-  aptible db:create HANDLE                                   # Create a new database
-  aptible db:deprovision HANDLE                              # Deprovision a database
-  aptible db:dump HANDLE                                     # Dump a remote database to file
-  aptible db:execute HANDLE SQL_FILE                         # Executes sql against a database
-  aptible db:list                                            # List all databases
-  aptible db:reload HANDLE                                   # Reload a database
-  aptible db:tunnel HANDLE                                   # Create a local tunnel to a database
-  aptible domains                                            # Print an app's current virtual domains
-  aptible help [COMMAND]                                     # Describe available commands or one specific command
-  aptible login                                              # Log in to Aptible
-  aptible logs                                               # Follows logs from a running app or database
-  aptible operation:cancel OPERATION_ID                      # Cancel a running operation
-  aptible ps                                                 # Display running processes for an app - DEPRECATED
-  aptible rebuild                                            # Rebuild an app, and restart its services
-  aptible restart                                            # Restart all services associated with an app
-  aptible ssh [COMMAND]                                      # Run a command against an app
-  aptible version                                            # Print Aptible CLI version
+  aptible apps                                                                  # List all applications
+  aptible apps:create HANDLE                                                    # Create a new application
+  aptible apps:deprovision                                                      # Deprovision an app
+  aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE]  # Scale a service
+  aptible backup:list DB_HANDLE                                                 # List backups for a database
+  aptible backup:restore [--handle HANDLE] [--size SIZE_GB]                     # Restore a backup
+  aptible config                                                                # Print an app's current configuration
+  aptible config:add                                                            # Add an ENV variable to an app
+  aptible config:rm                                                             # Remove an ENV variable from an app
+  aptible config:set                                                            # Alias for config:add
+  aptible config:unset                                                          # Alias for config:rm
+  aptible db:backup HANDLE                                                      # Backup a database
+  aptible db:clone SOURCE DEST                                                  # Clone a database to create a new one
+  aptible db:create HANDLE                                                      # Create a new database
+  aptible db:deprovision HANDLE                                                 # Deprovision a database
+  aptible db:dump HANDLE                                                        # Dump a remote database to file
+  aptible db:execute HANDLE SQL_FILE                                            # Executes sql against a database
+  aptible db:list                                                               # List all databases
+  aptible db:reload HANDLE                                                      # Reload a database
+  aptible db:tunnel HANDLE                                                      # Create a local tunnel to a database
+  aptible domains                                                               # Print an app's current virtual domains
+  aptible help [COMMAND]                                                        # Describe available commands or one specific command
+  aptible login                                                                 # Log in to Aptible
+  aptible logs                                                                  # Follows logs from a running app or database
+  aptible operation:cancel OPERATION_ID                                         # Cancel a running operation
+  aptible ps                                                                    # Display running processes for an app - DEPRECATED
+  aptible rebuild                                                               # Rebuild an app, and restart its services
+  aptible restart                                                               # Restart all services associated with an app
+  aptible ssh [COMMAND]                                                         # Run a command against an app
+  aptible version                                                               # Print Aptible CLI version
 ```
 
 ## Contributing


### PR DESCRIPTION
This changes the aptible apps:scale option format to treat container
count and container size as two "equal" options, rather than always
require container count to be provided as a positional argument and
allow container size to be provided as an afterthought.

To do so, both options are now positional arguments. I have however also
*renamed* one of the options: `--size` is now `--container-size`.

The rationale here is that we also use `--size` for `db:create` and
`backup:restore` in order to reference the size of the disk, but when we
introduce self-service DB scaling, we're going to want to also allow
specifying the container size, and that parameter will have to be named
differently (presumably `--container-size`).

In other words, for the sake of consistency, I'm updating `apps:scale`
to use `--container-` prefixes in the options so that the DB operations
can use the same parameters going forward.

Now, all these changes are potentially breaking changes, which we'd
rather avoid, so I've made sure to continue supporting the legacy
command line options (I did refactor most tests we had here, but I
confirmed the old tests were passing with the new code beforehand, and
I've kept tests for the old behavior around).

Finally, as we discussed, I also removed the size enum from the
`--container-size` option, since API will now be providing the list of
valid values if the user tries to use an unsupported size. This ensures
we won't need new CLI releases if new sizes are made available.

---

cc @fancyremarker 