### PR TITLE
Add support for database scaling

### DIFF
--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -35,7 +35,7 @@ module Aptible
             end
 
             desc 'apps:scale SERVICE ' \
-                 '[--container-count COUNT] [--container-size SIZE]',
+                 '[--container-count COUNT] [--container-size SIZE_MB]',
                  'Scale a service'
             app_options
             option :container_count, type: :numeric

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -7,9 +7,11 @@ module Aptible
             include Helpers::Token
             include Helpers::Database
 
-            desc 'backup:restore [--handle HANDLE] [--size SIZE_GB]',
+            desc 'backup:restore BACKUP_ID [--handle HANDLE] ' \
+                 '[--container-size SIZE_MB] [--size SIZE_GB]',
                  'Restore a backup'
             option :handle
+            option :container_size, type: :numeric
             option :size, type: :numeric
             define_method 'backup:restore' do |backup_id|
               backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
@@ -23,6 +25,7 @@ module Aptible
               opts = {
                 type: 'restore',
                 handle: handle,
+                container_size: options[:container_size],
                 disk_size: options[:size]
               }.delete_if { |_, v| v.nil? }
 

--- a/spec/aptible/cli/subcommands/backup_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_spec.rb
@@ -47,19 +47,47 @@ describe Aptible::CLI::Agent do
         expect(messages).to eq(["Restoring backup into #{h}"])
       end
 
-      it 'accepts a custom handle and disk size' do
+      it 'accepts a handle' do
         h = 'some-handle'
-        s = 40
 
         expect(backup).to receive(:create_operation!) do |options|
           expect(options[:handle]).to eq(h)
+          expect(options[:container_size]).to be_nil
+          expect(options[:disk_size]).to be_nil
+          op
+        end
+
+        subject.options = { handle: h }
+        subject.send('backup:restore', 1)
+        expect(messages).to eq(["Restoring backup into #{h}"])
+      end
+
+      it 'accepts a container size' do
+        s = 40
+
+        expect(backup).to receive(:create_operation!) do |options|
+          expect(options[:handle]).to be_present
+          expect(options[:container_size]).to eq(s)
+          expect(options[:disk_size]).to be_nil
+          op
+        end
+
+        subject.options = { container_size: s }
+        subject.send('backup:restore', 1)
+      end
+
+      it 'accepts a disk size' do
+        s = 40
+
+        expect(backup).to receive(:create_operation!) do |options|
+          expect(options[:handle]).to be_present
+          expect(options[:container_size]).to be_nil
           expect(options[:disk_size]).to eq(s)
           op
         end
 
-        subject.options = { handle: h, size: s }
+        subject.options = { size: s }
         subject.send('backup:restore', 1)
-        expect(messages).to eq(["Restoring backup into #{h}"])
       end
     end
   end


### PR DESCRIPTION
This adds support for a `--container-size` option on `db:create` and
`db:reload`, and adds a new `db:restart` operation that can be used to
resize database containers and disks.

There isn't much going on here, with one notable exception: since we now
allow customers to pass an arbitrary size when creating databases via
`db:create`, we can easily get into a situation where we never attempt
provisioning a database, because the `provision` operation was rejected
in API.

In that case, we'll enqueue a deprovision operation to clean it up.

--

cc @fancyremarker 