### PR TITLE
aptible ssh: return command exit code

### DIFF
--- a/lib/aptible/cli/helpers/operation.rb
+++ b/lib/aptible/cli/helpers/operation.rb
@@ -28,7 +28,7 @@ module Aptible
           # connecting for. There might be ways to make this better.
           ENV['ACCESS_TOKEN'] = fetch_token
 
-          success = connect_to_ssh_portal(
+          code = connect_to_ssh_portal(
             operation,
             '-o', 'SendEnv=ACCESS_TOKEN'
           )
@@ -36,7 +36,10 @@ module Aptible
           # If the portal is down, fall back to polling for success. If the
           # operation failed, poll_for_success will immediately fall through to
           # the error message.
-          poll_for_success(operation) unless success
+          unless code == 0
+            puts 'Disconnected from logs, waiting for operation to complete'
+            poll_for_success(operation)
+          end
         end
 
         def cancel_operation(operation)

--- a/lib/aptible/cli/helpers/ssh.rb
+++ b/lib/aptible/cli/helpers/ssh.rb
@@ -3,31 +3,48 @@ module Aptible
     module Helpers
       module Ssh
         def connect_to_ssh_portal(operation, *extra_ssh_args)
+          # NOTE: This is a little tricky to get rigt, so before you make any
+          # changes, read this.
+          #
+          # - The first gotcha is that we cannot use Kernel.exec here, because
+          # we need to perform cleanup when exiting from
+          # operation#with_ssh_cmd.
+          #
+          # - The second gotcha is that we need to somehow capture the exit
+          # status, so that CLI commands that call the SSH portal can proxy
+          # this back to their own caller (the most important one here is
+          # aptible ssh).
+          #
+          # To do this, we have to handle interrutps as a signal, as opposed to
+          # handle an Interrupt exception. The reason for this has to do with
+          # how Ruby's wait is implemented (this happens in process.c's
+          # rb_waitpid). There are two main considerations here:
+          #
+          # - It automatically resumes when it receives EINTR, so our control
+          # is pretty high-level here.
+          # - It handles interrupts prior to setting $? (this appears to have
+          # changed between Ruby 2.2 and 2.3, perhaps the newer implementation
+          # behaves differently).
+          #
+          # Unfortunately, this means that if we receive SIGINT while in
+          # Process::wait2, then we never get access to SSH's exitstatus: Ruby
+          # throws a Interrupt so we don't have a return value, and it doesn't
+          # set $?, so we can't read it back there.
+          #
+          # Of course, we can't just call Proces::wait2 again, because at this
+          # point, we've reaped our child.
+          #
+          # To solve this, we add our own signal handler on SIGINT, which
+          # simply proxies SIGINT to SSH if we happen to have a different
+          # process group (which shouldn't be the case), just to be safe and
+          # let users exit the CLI.
           with_ssh_cmd(operation) do |base_ssh_cmd|
-            ssh_cmd = base_ssh_cmd + extra_ssh_args
-            begin
-              Kernel.system(*ssh_cmd)
-            rescue Interrupt
-              # Assuming we have a TTY, there are two cases here. Either SSH
-              # itself has a TTY, in which case it is controlling the TTY and
-              # the CLI won't be receiving SIGINT when CTRL+C is pressed, or
-              # SSH has no TTY, in which case the CLI and SSH are sharing the
-              # same process group, and will both receive SIGINT when CTRL+C
-              # is pressed and exit accordingly.
-              #
-              # I'm not sure how this *should* work on Windows, but it appears
-              # to work pretty much the same way, except that we'll get an ugly
-              # "Terminate batch job (Y/N)?" prompt in the no-TTY-for-SSH case,
-              # which we're likely to have a hard time handling.
-              #
-              # Note that this DOES NOT handle the case where the CLI is sent
-              # SIGINT by another process (as opposed to the line discipline).
-              # In this case, SSH will continue running in the background. This
-              # is something we should fix, but for now this 'simple' fix is
-              # enough to addresses the ugly stack trace we show when
-              # CTRL+C'ing out of logs.
-            end
+            spawn_passthrough(base_ssh_cmd + extra_ssh_args)
           end
+        end
+
+        def exit_with_ssh_portal(*args)
+          exit connect_to_ssh_portal(*args)
         end
 
         def with_ssh_cmd(operation)
@@ -41,6 +58,40 @@ module Aptible
         end
 
         private
+
+        def spawn_passthrough(command)
+          redirection = { in: :in, out: :out, err: :err, close_others: true }
+          pid = Process.spawn(*command, redirection)
+
+          reset = Signal.trap('SIGINT') do
+            # FIXME: If we're on Windows, we don't really know whether SSH
+            # received SIGINT or not, so for now, we just ignore it.
+            next if Gem.win_platform?
+
+            begin
+              # SSH should be running in our process group, which means that
+              # if the user sends CTRL+C, we'll both receive it. In this
+              # case, just ignore the signal and let SSH handle it.
+              next if Process.getpgid(Process.pid) == Process.getpgid(pid)
+
+              # If we get here, then oddly, SSH is not running in our process
+              # group and yet we got the signal. In this case, let's simply
+              # ignore it.
+              Process.kill(:SIGINT, pid)
+            rescue Errno::ESRCH
+              # This could happen if SSH exited after receiving the SIGINT,
+              # Ruby waited it, then ran our signal handler. In this case, we
+              # don't need to do anything, so we proceed.
+            end
+          end
+
+          begin
+            _, status = Process.wait2(pid)
+            return status.exited? ? status.exitstatus : 128 + status.termsig
+          ensure
+            Signal.trap('SIGINT', reset)
+          end
+        end
 
         def ensure_ssh_dir!
           FileUtils.mkdir_p(ssh_dir, mode: 0o700)

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -34,7 +34,7 @@ module Aptible
               op = resource.create_operation!(type: 'logs', status: 'succeeded')
 
               ENV['ACCESS_TOKEN'] = fetch_token
-              connect_to_ssh_portal(op, '-o', 'SendEnv=ACCESS_TOKEN', '-T')
+              exit_with_ssh_portal(op, '-o', 'SendEnv=ACCESS_TOKEN', '-T')
             end
           end
         end

--- a/lib/aptible/cli/subcommands/ps.rb
+++ b/lib/aptible/cli/subcommands/ps.rb
@@ -20,7 +20,7 @@ module Aptible
 
               ENV['ACCESS_TOKEN'] = fetch_token
               opts = ['-o', 'SendEnv=ACCESS_TOKEN']
-              connect_to_ssh_portal(op, *opts)
+              exit_with_ssh_portal(op, *opts)
             end
           end
         end

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -57,7 +57,7 @@ module Aptible
                          end
               opts << tty_mode
 
-              connect_to_ssh_portal(op, *opts)
+              exit_with_ssh_portal(op, *opts)
             end
 
             private

--- a/spec/aptible/cli/helpers/ssh_spec.rb
+++ b/spec/aptible/cli/helpers/ssh_spec.rb
@@ -89,4 +89,125 @@ describe Aptible::CLI::Helpers::Ssh do
       expect(has_yielded).to be_truthy
     end
   end
+
+  describe '#spawn_passthrough' do
+    let(:bins) { File.expand_path('../../../../script', __FILE__) }
+    let(:ruby) { Gem.win_platform? ? 'ruby.exe' : 'ruby' }
+    let(:wrapper) { [ruby, File.join(bins, 'ssh-spawn')] }
+    let(:exit_with) { [ruby, File.join(bins, 'exit-with')] }
+    let(:sigint) { [ruby, File.join(bins, 'pid-signal')] }
+    let(:setpgid) { [ruby, File.join(bins, 'setpgid')] }
+
+    let(:cleanup) { [] }
+
+    after do
+      cleanup.each do |pid|
+        begin
+          Process.kill(:SIGKILL, -pid)
+        rescue Errno::ESRCH, Errno::EINVAL
+        end
+      end
+    end
+
+    def spawn_with_cleanup(*args)
+      kw = Gem.win_platform? ? { new_pgroup: true } : { pgroup: true }
+      Process.spawn(*args, **kw).tap { |pid| cleanup << pid }
+    end
+
+    def wait_for_file(file)
+      50.times do
+        return if File.exist?(file)
+        sleep 0.1
+      end
+
+      raise "File never showed up: #{file}"
+    end
+
+    def wait_for_pid(pid, timeout = 5)
+      (timeout * 10).times do
+        _, status = Process.wait2(pid, Process::WNOHANG)
+        return status if status
+        sleep 0.1
+      end
+
+      raise "PID never exited: #{pid}"
+    end
+
+    [0, 1].each do |c|
+      it "returns the command exit code (#{c})" do
+        pid = spawn_with_cleanup(*wrapper, *exit_with, c.to_s)
+        status = wait_for_pid(pid)
+        expect(status.exitstatus).to eq(c)
+      end
+    end
+
+    context 'signals' do
+      # Don't run these on Windows: sending SIGINT will send it to the entire
+      # console group, which includes the process running the specs.
+      before { skip 'Windows' if Gem.win_platform? }
+
+      it 'returns 128 + signal number when signalled' do
+        Dir.mktmpdir do |dir|
+          pid_file = File.join(dir, 'pid')
+          pid = spawn_with_cleanup(*wrapper, *sigint, pid_file)
+          wait_for_file(pid_file)
+
+          child_pid = Integer(File.read(pid_file).chomp)
+          Process.kill('INT', child_pid)
+
+          status = wait_for_pid(pid)
+
+          if Gem.win_platform?
+            expect(status.exitstatus).not_to eq(0)
+          else
+            expect(status.exitstatus).to eq(128 + Signal.list.fetch('INT'))
+          end
+        end
+      end
+
+      it 'does not proxy SIGINT when part of the same process group' do
+        Dir.mktmpdir do |dir|
+          pid_file = File.join(dir, 'pid')
+          pid = spawn_with_cleanup(*wrapper, *sigint, pid_file)
+          wait_for_file(pid_file)
+
+          child_pid = Integer(File.read(pid_file).chomp)
+          expect(Process.getpgid(child_pid)).to eq(Process.getpgid(pid))
+          Process.kill('INT', pid)
+
+          expect { wait_for_pid(pid, 2) }.to raise_error(/never exited/im)
+        end
+      end
+
+      it 'proxies SIGINT when process groups are different' do
+        Dir.mktmpdir do |dir|
+          pid_file = File.join(dir, 'pid')
+          pid = spawn_with_cleanup(*wrapper, *setpgid, *sigint, pid_file)
+          wait_for_file(pid_file)
+
+          child_pid = Integer(File.read(pid_file).chomp)
+          expect(Process.getpgid(child_pid)).not_to eq(Process.getpgid(pid))
+          Process.kill('INT', pid)
+
+          status = wait_for_pid(pid)
+          expect(status.exitstatus).to eq(128 + Signal.list.fetch('INT'))
+        end
+      end
+
+      it 'does not crash when receiving SIGINT concurrently' do
+        Dir.mktmpdir do |dir|
+          pid_file = File.join(dir, 'pid')
+          pid = spawn_with_cleanup(*wrapper, *sigint, pid_file)
+          wait_for_file(pid_file)
+
+          child_pid = Integer(File.read(pid_file).chomp)
+          expect(Process.getpgid(child_pid)).to eq(Process.getpgid(pid))
+          Process.kill('INT', -pid)
+
+          status = wait_for_pid(pid)
+          expect(status.exitstatus).to eq(128 + Signal.list.fetch('INT'))
+        end
+      end
+    end
+  end
 end

--- a/spec/aptible/cli/subcommands/logs_spec.rb
+++ b/spec/aptible/cli/subcommands/logs_spec.rb
@@ -27,7 +27,7 @@ describe Aptible::CLI::Agent do
         expect(app).to receive(:create_operation!).with(
           type: 'logs', status: 'succeeded'
         ).and_return(op)
-        expect(subject).to receive(:connect_to_ssh_portal).with(op, any_args)
+        expect(subject).to receive(:exit_with_ssh_portal).with(op, any_args)
         subject.send('logs')
       end
     end
@@ -47,7 +47,7 @@ describe Aptible::CLI::Agent do
         expect(database).to receive(:create_operation!).with(
           type: 'logs', status: 'succeeded'
         ).and_return(op)
-        expect(subject).to receive(:connect_to_ssh_portal).with(op, any_args)
+        expect(subject).to receive(:exit_with_ssh_portal).with(op, any_args)
         subject.send('logs')
       end
     end

--- a/spec/aptible/cli/subcommands/ssh_spec.rb
+++ b/spec/aptible/cli/subcommands/ssh_spec.rb
@@ -19,7 +19,7 @@ describe Aptible::CLI::Agent do
         allow(STDIN).to receive(:tty?).and_return(true)
         allow(STDOUT).to receive(:tty?).and_return(true)
 
-        expect(subject).to receive(:connect_to_ssh_portal).with(
+        expect(subject).to receive(:exit_with_ssh_portal).with(
           operation, '-o', 'SendEnv=ACCESS_TOKEN', '-t'
         )
         subject.ssh
@@ -30,7 +30,7 @@ describe Aptible::CLI::Agent do
         allow(STDOUT).to receive(:tty?).and_return(true)
         allow(STDERR).to receive(:tty?).and_return(false)
 
-        expect(subject).to receive(:connect_to_ssh_portal).with(
+        expect(subject).to receive(:exit_with_ssh_portal).with(
           operation, '-o', 'SendEnv=ACCESS_TOKEN', '-t'
         )
         subject.ssh
@@ -40,7 +40,7 @@ describe Aptible::CLI::Agent do
         allow(STDIN).to receive(:tty?).and_return(false)
         allow(STDOUT).to receive(:tty?).and_return(true)
 
-        expect(subject).to receive(:connect_to_ssh_portal).with(
+        expect(subject).to receive(:exit_with_ssh_portal).with(
           operation, '-o', 'SendEnv=ACCESS_TOKEN', '-T'
         )
         subject.ssh
@@ -50,7 +50,7 @@ describe Aptible::CLI::Agent do
         allow(STDIN).to receive(:tty?).and_return(true)
         allow(STDOUT).to receive(:tty?).and_return(false)
 
-        expect(subject).to receive(:connect_to_ssh_portal).with(
+        expect(subject).to receive(:exit_with_ssh_portal).with(
           operation, '-o', 'SendEnv=ACCESS_TOKEN', '-T'
         )
         subject.ssh
@@ -62,7 +62,7 @@ describe Aptible::CLI::Agent do
         allow(STDIN).to receive(:tty?).and_return(false)
         allow(STDOUT).to receive(:tty?).and_return(false)
 
-        expect(subject).to receive(:connect_to_ssh_portal).with(
+        expect(subject).to receive(:exit_with_ssh_portal).with(
           operation, '-o', 'SendEnv=ACCESS_TOKEN', '-tt'
         )
         subject.ssh

--- a/spec/script/exit-with
+++ b/spec/script/exit-with
@@ -1,0 +1,2 @@
+#!/usr/bin/env ruby
+exit Integer(ARGV.fetch(0))

--- a/spec/script/pid-signal
+++ b/spec/script/pid-signal
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+File.write(ARGV.fetch(0), Process.pid.to_s)
+Signal.trap('INT', 'SYSTEM_DEFAULT')
+sleep 30

--- a/spec/script/setpgid
+++ b/spec/script/setpgid
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+kw = Gem.win_platform? ? { new_pgroup: true } : { pgroup: true }
+exec(*ARGV, **kw)

--- a/spec/script/ssh-spawn
+++ b/spec/script/ssh-spawn
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require 'aptible/cli/helpers/ssh'
+include Aptible::CLI::Helpers::Ssh
+exit spawn_passthrough(ARGV)


### PR DESCRIPTION
This was an unfortunate regression introduced in #206: since we'd like
to clean up the certificate after ourselves (even though it'll expire
soon), we can no longer simply use Kernel::exec when running aptible
ssh.

I inadvertently converted this to use Kernel::system instead, but did
not pay attention to the fact that this swallows ssh's exit code. This
patch restores the original behavior. See the inline comments for how /
why it works.

---

cc @fancyremarker - I'll also be adding integration tests in https://github.com/aptible/aptible-integration to make sure we don't regress on this in the future.