### PR TITLE
Introduce aptible deploy (Direct Docker Deploy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Commands:
   aptible db:reload HANDLE                                                                        # Reload a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                           # Restart a database
   aptible db:tunnel HANDLE                                                                        # Create a local tunnel to a database
+  aptible deploy [OPTIONS] [VAR1=VAL1] [VAR=VAL2] ...                                             # Deploy an app
   aptible domains                                                                                 # Print an app's current virtual domains
   aptible help [COMMAND]                                                                          # Describe available commands or one specific command
   aptible login                                                                                   # Log in to Aptible

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -20,6 +20,7 @@ require_relative 'subcommands/domains'
 require_relative 'subcommands/logs'
 require_relative 'subcommands/ps'
 require_relative 'subcommands/rebuild'
+require_relative 'subcommands/deploy'
 require_relative 'subcommands/restart'
 require_relative 'subcommands/ssh'
 require_relative 'subcommands/backup'
@@ -40,6 +41,7 @@ module Aptible
       include Subcommands::Logs
       include Subcommands::Ps
       include Subcommands::Rebuild
+      include Subcommands::Deploy
       include Subcommands::Restart
       include Subcommands::SSH
       include Subcommands::Backup

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -140,6 +140,21 @@ module Aptible
           end.select { |a| a.handle == handle }
         end
 
+        def extract_env(args)
+          Hash[args.map do |arg|
+            k, v = arg.split('=', 2)
+            validate_env_key!(k)
+            [k, v]
+          end]
+        end
+
+        def validate_env_key!(k)
+          # Keys that start with '-' are likely to be mispelled options. As of
+          # May 2017 (> 3 years of Aptible!), there are only 2 such cases, both
+          # of which are indeed mispelled options.
+          raise Thor::Error, "Invalid argument: #{k}" if k.start_with?('-')
+        end
+
         private
 
         def handle_strategies

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -23,7 +23,7 @@ module Aptible
             define_method 'config:add' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
-              env = Hash[args.map { |arg| arg.split('=', 2) }]
+              env = extract_env(args)
               operation = app.create_operation!(type: 'configure', env: env)
               puts 'Updating configuration and restarting app...'
               attach_to_operation_logs(operation)
@@ -40,7 +40,10 @@ module Aptible
             define_method 'config:rm' do |*args|
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
-              env = Hash[args.map { |arg| [arg, ''] }]
+              env = Hash[args.map do |arg|
+                validate_env_key!(arg)
+                [arg, '']
+              end]
               operation = app.create_operation!(type: 'configure', env: env)
               puts 'Updating configuration and restarting app...'
               attach_to_operation_logs(operation)

--- a/lib/aptible/cli/subcommands/deploy.rb
+++ b/lib/aptible/cli/subcommands/deploy.rb
@@ -1,0 +1,78 @@
+module Aptible
+  module CLI
+    module Subcommands
+      module Deploy
+        DOCKER_IMAGE_DEPLOY_ARGS = Hash[%w(
+          APTIBLE_DOCKER_IMAGE
+          APTIBLE_PRIVATE_REGISTRY_EMAIL
+          APTIBLE_PRIVATE_REGISTRY_USERNAME
+          APTIBLE_PRIVATE_REGISTRY_PASSWORD
+        ).map do |var|
+          opt = var.gsub(/^APTIBLE_/, '').downcase.to_sym
+          [opt, var]
+        end]
+
+        NULL_SHA1 = '0000000000000000000000000000000000000000'.freeze
+
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::Operation
+            include Helpers::App
+
+            desc 'deploy [OPTIONS] [VAR1=VAL1] [VAR=VAL2] ...', 'Deploy an app'
+            option :git_commitish,
+                   desc: 'Deploy a specific git commit or branch: the ' \
+                         'commitish must have been pushed to Aptible beforehand'
+            option :git_detach,
+                   type: :boolean, default: false,
+                   desc: 'Detach this app from its git repository: ' \
+                         'its Procfile, Dockerfile, and .aptible.yml will be ' \
+                         'ignored until you deploy again with git'
+            DOCKER_IMAGE_DEPLOY_ARGS.each_pair do |opt, var|
+              option opt,
+                     type: :string, banner: var,
+                     desc: "Shorthand for #{var}=..."
+            end
+            app_options
+            def deploy(*args)
+              app = ensure_app(options)
+
+              git_ref = options[:git_commitish]
+              if options[:git_detach]
+                if git_ref
+                  raise Thor::Error, 'The options --git-committish and ' \
+                                     '--git-detach are incompatible'
+                end
+                git_ref = NULL_SHA1
+              end
+
+              env = extract_env(args)
+
+              DOCKER_IMAGE_DEPLOY_ARGS.each_pair do |opt, var|
+                val = options[opt]
+                next unless val
+                if env[var] && env[var] != val
+                  dasherized = "--#{opt.to_s.tr('_', '-')}"
+                  raise Thor::Error, "The options #{dasherized} and #{var} " \
+                                     'to different values'
+                end
+                env[var] = val
+              end
+
+              opts = {
+                type: 'deploy',
+                env: env,
+                git_ref: git_ref
+              }.delete_if { |_, v| v.nil? || v.empty? }
+
+              operation = app.create_operation!(opts)
+
+              puts 'Deploying app...'
+              attach_to_operation_logs(operation)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/subcommands/deploy.rb
+++ b/lib/aptible/cli/subcommands/deploy.rb
@@ -54,7 +54,7 @@ module Aptible
                 if env[var] && env[var] != val
                   dasherized = "--#{opt.to_s.tr('_', '-')}"
                   raise Thor::Error, "The options #{dasherized} and #{var} " \
-                                     'to different values'
+                                     'cannot be set to different values'
                 end
                 env[var] = val
               end
@@ -64,6 +64,17 @@ module Aptible
                 env: env,
                 git_ref: git_ref
               }.delete_if { |_, v| v.nil? || v.empty? }
+
+              allow_it = [
+                opts[:git_ref],
+                opts[:env].try(:[], 'APTIBLE_DOCKER_IMAGE'),
+                app.status == 'provisioned'
+              ].any? { |x| x }
+
+              unless allow_it
+                m = 'You need to deploy either from git or a Docker image'
+                raise Thor::Error, m
+              end
 
               operation = app.create_operation!(opts)
 

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -165,6 +165,34 @@ describe Aptible::CLI::Agent do
     end
   end
 
+  describe '#config:set' do
+    before do
+      allow(Aptible::Api::App).to receive(:all) { [app] }
+      allow(Aptible::Api::Account).to receive(:all) { [account] }
+    end
+
+    it 'should reject environment variables that start with -' do
+      allow(subject).to receive(:options) { { app: 'hello' } }
+
+      expect { subject.send('config:set', '-foo=bar') }
+        .to raise_error(/invalid argument/im)
+    end
+  end
+
+  describe '#config:rm' do
+    before do
+      allow(Aptible::Api::App).to receive(:all) { [app] }
+      allow(Aptible::Api::Account).to receive(:all) { [account] }
+    end
+
+    it 'should reject environment variables that start with -' do
+      allow(subject).to receive(:options) { { app: 'hello' } }
+
+      expect { subject.send('config:rm', '-foo') }
+        .to raise_error(/invalid argument/im)
+    end
+  end
+
   describe '#ensure_app' do
     it 'fails if no usable strategy is found' do
       strategies = [dummy_strategy_factory(nil, nil, false)]

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -1,0 +1,149 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  let!(:account) { Fabricate(:account, handle: 'foobar') }
+  let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
+  let(:operation) { Fabricate(:operation) }
+
+  describe '#deploy' do
+    before do
+      allow(Aptible::Api::App).to receive(:all) { [app] }
+      allow(Aptible::Api::Account).to receive(:all) { [account] }
+      subject.stub(:fetch_token) { double 'token' }
+    end
+
+    context 'with app' do
+      let(:base_options) { { app: app.handle, environment: account.handle } }
+
+      def stub_options(**opts)
+        allow(subject).to receive(:options).and_return(base_options.merge(opts))
+      end
+
+      it 'deploys' do
+        stub_options
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy').and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy
+      end
+
+      it 'deploys a committish' do
+        stub_options(git_commitish: 'foobar')
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', git_ref: 'foobar').and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy
+      end
+
+      it 'deploys a Docker image' do
+        stub_options(docker_image: 'foobar')
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', env: { 'APTIBLE_DOCKER_IMAGE' => 'foobar' })
+          .and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy
+      end
+
+      it 'deploys with credentials' do
+        stub_options(
+          private_registry_email: 'foo',
+          private_registry_username: 'bar',
+          private_registry_password: 'qux'
+        )
+
+        env = {
+          'APTIBLE_PRIVATE_REGISTRY_EMAIL' => 'foo',
+          'APTIBLE_PRIVATE_REGISTRY_USERNAME' => 'bar',
+          'APTIBLE_PRIVATE_REGISTRY_PASSWORD' => 'qux'
+        }
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', env: env)
+          .and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy
+      end
+
+      it 'detaches a git repo' do
+        stub_options(git_detach: true)
+
+        ref = '0000000000000000000000000000000000000000'
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', git_ref: ref)
+          .and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy
+      end
+
+      it 'fails if detaching the git repo and providing a commitish' do
+        stub_options(git_commitish: 'foo', git_detach: true)
+
+        expect { subject.deploy }.to raise_error(/are incompatible/im)
+      end
+
+      it 'allows setting configuration variables' do
+        stub_options
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', env: { 'FOO' => 'bar', 'BAR' => 'qux' })
+          .and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy('FOO=bar', 'BAR=qux')
+      end
+
+      it 'allows unsetting configuration variables' do
+        stub_options
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', env: { 'FOO' => '' })
+          .and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy('FOO=')
+      end
+
+      it 'rejects arguments with a leading -' do
+        stub_options
+
+        expect { subject.deploy('--aptible-docker-image=bar') }
+          .to raise_error(/invalid argument/im)
+      end
+
+      it 'allows redundant command line arguments' do
+        stub_options(docker_image: 'foobar')
+
+        expect(app).to receive(:create_operation!)
+          .with(type: 'deploy', env: { 'APTIBLE_DOCKER_IMAGE' => 'foobar' })
+          .and_return(operation)
+        expect(subject).to receive(:attach_to_operation_logs)
+          .with(operation)
+
+        subject.deploy('APTIBLE_DOCKER_IMAGE=foobar')
+      end
+
+      it 'reject contradictory command line argumnts' do
+        stub_options(docker_image: 'foobar')
+
+        expect { subject.deploy('APTIBLE_DOCKER_IMAGE=qux') }
+          .to raise_error(/different values/im)
+      end
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -144,6 +144,15 @@ describe Aptible::CLI::Agent do
         expect { subject.deploy('APTIBLE_DOCKER_IMAGE=qux') }
           .to raise_error(/different values/im)
       end
+
+      it 'does not allow deploying nothing on an unprovisioned app' do
+        stub_options
+
+        app.stub(status: 'pending')
+
+        expect { subject.deploy }
+          .to raise_error(/either from git.*docker/im)
+      end
     end
   end
 end


### PR DESCRIPTION
This command can be used in a few ways by customers:

First, it can be used to update an app to deploy from a Docker image (or
update its current Docker image), as well as set environment variables.

```
aptible deploy --app foobar --docker-image httpd:alpine FOO=BAR
```

When this is done, the app's `Dockerfile` will be ignored going forward.
However, other repo files might still influence the deploy.

Specifically, there are two possible cases:

- The app was deployed from git at some point in the past. In this case,
  the Docker image deploy will inherit the app's `Procfile` and
  `.aptible.yml`, if any. Enclave will fallback to the image's `CMD` as
  a `Procfile` substitute if none exists.
- The app was never deployed from `git`. In this case there is no
  `Procfile` or `.aptible.yml`, and Enclave uses the image's `CMD`. This
  is the recommended approach for users deploying from a Docker image.

It's also possible to completely remove the link to the git repo. When
that's done, the files found in the git repo will be ignored going
forward.

```
aptible deploy --app foobar --git-detach
```

But that's not all! It's also possible to *go back* to having a git repo
without a `git push`.

This is useful since a `git push` may not trigger a deploy if there are
no changes)

```
aptible deploy --app foobar --git-commitish master
```

Finally, it's possible to remove the app's Docker image to go back to a
`Dockerfile` build, albeit with a non-ideal syntax for now:

```
aptible deploy --app foobar APTIBLE_DOCKER_IMAGE=
```

---

cc @fancyremarker @UserNotFound 