### PR TITLE
Add a db:url command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Commands:
   aptible db:reload HANDLE                                                                        # Reload a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                           # Restart a database
   aptible db:tunnel HANDLE                                                                        # Create a local tunnel to a database
+  aptible db:url HANDLE                                                                           # Display a database URL
   aptible deploy [OPTIONS] [VAR1=VAL1] [VAR=VAL2] ...                                             # Deploy an app
   aptible domains                                                                                 # Print an app's current virtual domains
   aptible help [COMMAND]                                                                          # Describe available commands or one specific command

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -78,7 +78,7 @@ module Aptible
             raise Thor::Error, 'This command only works for PostgreSQL'
           end
 
-          credential = find_tunnel_credential(database)
+          credential = find_credential(database)
 
           with_local_tunnel(credential) do |tunnel_helper|
             yield local_url(credential, tunnel_helper.port)
@@ -93,7 +93,7 @@ module Aptible
           "localhost.aptible.in:#{local_port}#{uri.path}"
         end
 
-        def find_tunnel_credential(database, type = nil)
+        def find_credential(database, type = nil)
           unless database.provisioned?
             raise Thor::Error, "Database #{database.handle} is not provisioned"
           end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -177,6 +177,13 @@ module Aptible
               op = database.create_operation!(opts)
               attach_to_operation_logs(op)
             end
+
+            desc 'db:url HANDLE', 'Display a database URL'
+            option :environment
+            define_method 'db:url' do |handle|
+              database = ensure_database(options.merge(db: handle))
+              say(database.connection_url)
+            end
           end
         end
       end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -95,7 +95,7 @@ module Aptible
               desired_port = Integer(options[:port] || 0)
               database = ensure_database(options.merge(db: handle))
 
-              credential = find_tunnel_credential(database, options[:type])
+              credential = find_credential(database, options[:type])
 
               say "Creating #{credential.type} tunnel to #{database.handle}...",
                   :green
@@ -180,9 +180,12 @@ module Aptible
 
             desc 'db:url HANDLE', 'Display a database URL'
             option :environment
+            option :type, type: :string
             define_method 'db:url' do |handle|
               database = ensure_database(options.merge(db: handle))
-              say(database.connection_url)
+              credential = find_credential(database, options[:type])
+
+              say(credential.connection_url)
             end
           end
         end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -17,10 +17,12 @@ def dummy_strategy_factory(app_handle, env_handle, usable,
 end
 
 describe Aptible::CLI::Agent do
-  before { subject.stub(:ask) }
-  before { subject.stub(:save_token) }
-  before { subject.stub(:fetch_token) { double 'token' } }
-  before { subject.stub(:attach_to_operation_logs) }
+  before do
+    allow(subject).to receive(:ask)
+    allow(subject).to receive(:save_token)
+    allow(subject).to receive(:attach_to_operation_logs)
+    allow(subject).to receive(:fetch_token) { double 'token' }
+  end
 
   let!(:account) { Fabricate(:account) }
   let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
@@ -196,14 +198,14 @@ describe Aptible::CLI::Agent do
   describe '#ensure_app' do
     it 'fails if no usable strategy is found' do
       strategies = [dummy_strategy_factory(nil, nil, false)]
-      subject.stub(:handle_strategies) { strategies }
+      allow(subject).to receive(:handle_strategies) { strategies }
 
       expect { subject.ensure_app }.to raise_error(/Could not find app/)
     end
 
     it 'fails if an environment is specified but not found' do
       strategies = [dummy_strategy_factory('hello', 'aptible', true)]
-      subject.stub(:handle_strategies) { strategies }
+      allow(subject).to receive(:handle_strategies) { strategies }
 
       expect(subject).to receive(:environment_from_handle).and_return(nil)
 
@@ -220,7 +222,7 @@ describe Aptible::CLI::Agent do
 
       it 'scopes the app search to an environment if provided' do
         strategies = [dummy_strategy_factory('hello', 'aptible', true)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect(subject).to receive(:environment_from_handle).with('aptible')
           .and_return(account)
@@ -230,7 +232,7 @@ describe Aptible::CLI::Agent do
 
       it 'does not scope the app search to an environment if not provided' do
         strategies = [dummy_strategy_factory('hello', nil, true)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect(subject.ensure_app).to eq(apps.first)
       end
@@ -239,7 +241,7 @@ describe Aptible::CLI::Agent do
         apps.pop
 
         strategies = [dummy_strategy_factory('hello', nil, true)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect { subject.ensure_app }.to raise_error(/not find app hello/)
       end
@@ -248,7 +250,7 @@ describe Aptible::CLI::Agent do
         apps.pop
 
         strategies = [dummy_strategy_factory('hello', nil, true)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect { subject.ensure_app }.to raise_error(/from dummy/)
       end
@@ -257,7 +259,7 @@ describe Aptible::CLI::Agent do
         apps.pop
 
         strategies = [dummy_strategy_factory('hello', 'aptible', true)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect(subject).to receive(:environment_from_handle).with('aptible')
           .and_return(account)
@@ -269,7 +271,7 @@ describe Aptible::CLI::Agent do
         apps << Fabricate(:app, handle: 'hello')
 
         strategies = [dummy_strategy_factory('hello', nil, true)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect { subject.ensure_app }.to raise_error(/Multiple apps/)
       end
@@ -279,7 +281,7 @@ describe Aptible::CLI::Agent do
           dummy_strategy_factory('hello', nil, false),
           dummy_strategy_factory('hello', nil, true)
         ]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         expect(subject.ensure_app).to eq(apps.first)
       end
@@ -287,7 +289,7 @@ describe Aptible::CLI::Agent do
       it 'passes options to the strategy' do
         receiver = []
         strategies = [dummy_strategy_factory('hello', nil, false, receiver)]
-        subject.stub(:handle_strategies) { strategies }
+        allow(subject).to receive(:handle_strategies) { strategies }
 
         options = { app: 'foo', environment: 'bar' }
         expect { subject.ensure_app options }.to raise_error(/not find app/)

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -357,4 +357,26 @@ describe Aptible::CLI::Agent do
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
   end
+
+  describe '#db:url' do
+    let(:databases) { [database] }
+    before { expect(Aptible::Api::Database).to receive(:all) { databases } }
+
+    it 'returns the URL of a specified DB' do
+      expect(subject).to receive(:say).with(database.connection_url)
+      subject.send('db:url', handle)
+    end
+
+    it 'fails if the DB is not found' do
+      expect { subject.send('db:url', 'nope') }
+        .to raise_error(Thor::Error, 'Could not find database nope')
+    end
+
+    it 'fails if multiple DBs are found' do
+      databases << database
+
+      expect { subject.send('db:url', handle) }
+        .to raise_error(/Multiple databases/)
+    end
+  end
 end

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -362,21 +362,45 @@ describe Aptible::CLI::Agent do
     let(:databases) { [database] }
     before { expect(Aptible::Api::Database).to receive(:all) { databases } }
 
-    it 'returns the URL of a specified DB' do
-      expect(subject).to receive(:say).with(database.connection_url)
-      subject.send('db:url', handle)
-    end
-
     it 'fails if the DB is not found' do
       expect { subject.send('db:url', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
 
-    it 'fails if multiple DBs are found' do
-      databases << database
+    context 'valid database' do
+      it 'returns the URL of a specified DB' do
+        cred = Fabricate(:database_credential, default: true, type: 'foo',
+                                               database: database)
 
-      expect { subject.send('db:url', handle) }
-        .to raise_error(/Multiple databases/)
+        expect(subject).to receive(:say).with(cred.connection_url)
+        expect(database).not_to receive(:connection_url)
+
+        subject.send('db:url', handle)
+      end
+
+      it 'fails if multiple DBs are found' do
+        databases << database
+
+        expect { subject.send('db:url', handle) }
+          .to raise_error(/Multiple databases/)
+      end
+
+      context 'v1 stack' do
+        before do
+          allow(database.account.stack).to receive(:version) { 'v1' }
+          allow(subject).to receive(:say)
+        end
+
+        it 'returns the URL of a specified DB' do
+          connection_url = 'postgresql://aptible-v1:password@lega.cy:4242/db'
+
+          expect(subject).to receive(:say).with(connection_url)
+          expect(database).to receive(:connection_url)
+            .and_return(connection_url)
+
+          subject.send('db:url', handle)
+        end
+      end
     end
   end
 end

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -4,9 +4,11 @@ class SocatHelperMock < OpenStruct
 end
 
 describe Aptible::CLI::Agent do
-  before { subject.stub(:ask) }
-  before { subject.stub(:save_token) }
-  before { subject.stub(:fetch_token) { double 'token' } }
+  before do
+    allow(subject).to receive(:ask)
+    allow(subject).to receive(:save_token)
+    allow(subject).to receive(:fetch_token) { double 'token' }
+  end
 
   let(:handle) { 'foobar' }
   let(:database) { Fabricate(:database, handle: handle) }
@@ -20,7 +22,7 @@ describe Aptible::CLI::Agent do
     before do
       allow(Aptible::Api::Account).to receive(:all).and_return([account])
       allow(db).to receive(:reload).and_return(db)
-      op.stub(errors: Aptible::Resource::Errors.new)
+      allow(op).to receive(:errors).and_return(Aptible::Resource::Errors.new)
     end
 
     it 'creates a new DB' do
@@ -163,15 +165,17 @@ describe Aptible::CLI::Agent do
       end
 
       it 'fails when the database is not provisioned' do
-        database.stub(status: 'pending')
+        allow(database).to receive(:status) { 'pending' }
 
         expect { subject.send('db:tunnel', handle) }
           .to raise_error(/foobar is not provisioned/im)
       end
 
       context 'v1 stack' do
-        before { database.account.stack.stub(version: 'v1') }
-        before { allow(subject).to receive(:say) }
+        before do
+          allow(database.account.stack).to receive(:version) { 'v1' }
+          allow(subject).to receive(:say)
+        end
 
         it 'falls back to the database itself if no type is given' do
           expect(subject).to receive(:with_local_tunnel).with(database, 0)
@@ -180,7 +184,7 @@ describe Aptible::CLI::Agent do
 
         it 'falls back to the database itself if type matches' do
           subject.options = { type: 'bar' }
-          database.stub(type: 'bar')
+          allow(database).to receive(:type) { 'bar' }
 
           expect(subject).to receive(:with_local_tunnel).with(database, 0)
           subject.send('db:tunnel', handle)
@@ -188,7 +192,7 @@ describe Aptible::CLI::Agent do
 
         it 'does not fall back to the database itself if type mismatches' do
           subject.options = { type: 'bar' }
-          database.stub(type: 'foo')
+          allow(database).to receive(:type) { 'foo' }
 
           expect { subject.send('db:tunnel', handle) }
             .to raise_error(/no credential with type bar/im)
@@ -218,7 +222,7 @@ describe Aptible::CLI::Agent do
       end
 
       token = 'the-token'
-      allow(subject).to receive(:fetch_token).and_return(token)
+      allow(subject).to receive(:fetch_token) { token }
       allow(Aptible::Api::Account).to receive(:all).with(token: token)
         .and_return([staging, prod])
     end

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -9,7 +9,7 @@ describe Aptible::CLI::Agent do
     before do
       allow(Aptible::Api::App).to receive(:all) { [app] }
       allow(Aptible::Api::Account).to receive(:all) { [account] }
-      subject.stub(:fetch_token) { double 'token' }
+      allow(subject).to receive(:fetch_token) { double'token' }
     end
 
     context 'with app' do
@@ -148,7 +148,7 @@ describe Aptible::CLI::Agent do
       it 'does not allow deploying nothing on an unprovisioned app' do
         stub_options
 
-        app.stub(status: 'pending')
+        allow(app).to receive(:status) { 'pending' }
 
         expect { subject.deploy }
           .to raise_error(/either from git.*docker/im)

--- a/spec/aptible/cli/subcommands/domains_spec.rb
+++ b/spec/aptible/cli/subcommands/domains_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Aptible::CLI::Agent do
-  before { subject.stub(:ask) }
-  before { subject.stub(:save_token) }
-  before { subject.stub(:fetch_token) { double 'token' } }
+  before do
+    allow(subject).to receive(:ask)
+    allow(subject).to receive(:save_token)
+    allow(subject).to receive(:fetch_token) { double 'token' }
+  end
 
   let!(:account) { Fabricate(:account) }
   let!(:app) { Fabricate(:app, handle: 'hello', account: account) }

--- a/spec/aptible/cli/subcommands/logs_spec.rb
+++ b/spec/aptible/cli/subcommands/logs_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Aptible::CLI::Agent do
-  before { subject.stub(:ask) }
-  before { subject.stub(:save_token) }
-  before { subject.stub(:fetch_token) { 'some token' } }
+  before do
+    allow(subject).to receive(:ask)
+    allow(subject).to receive(:save_token)
+    allow(subject).to receive(:fetch_token) { 'some token' }
+  end
 
   let(:app) { Fabricate(:app, handle: 'foo') }
   let(:database) { Fabricate(:database, handle: 'bar', status: 'provisioned') }


### PR DESCRIPTION
## Context

Sometimes we want quick access to a database's URL from the command line.

### Changes

- Add a db:url command
  + Displays the URL for a specified database
    * Specify databse with handle
    * Raise error if database not found
    * Raise error if multiple databases found
  + Sync README.md with new subcommand
- Fix: Replace deprecated `stub` implementations
  + Cleanup "offenses" in test suite (_woops_ 😅 )
    * "Shadowing outer local variable - m."
    * "Line is too long."