### PR TITLE
Update README sync script & Contributing instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ rvm:
 
 script:
   - bundle exec rake
-  - bundle exec script/sync-readme-usage README.md
+  - bundle exec script/sync-readme-usage
   - git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Commands:
 1. Fork the project.
 1. Commit your changes, with specs.
 1. Ensure that your code passes specs (`rake spec`) and meets Aptible's Ruby style guide (`rake rubocop`).
-1. If you add a command, update this README with the output of `aptible help | grep -v help`.
+1. If you add a command, sync this README (`bundle exec script/sync-readme-usage`).
 1. Create a new pull request on GitHub.
 
 ## Contributors
@@ -82,6 +82,7 @@ Commands:
 * Daniel Levenson ([@dleve123](https://github.com/dleve123))
 * Ryan Aipperspach ([@ryanaip](https://github.com/ryanaip))
 * Chas Ballew ([@chasballew](https://github.com/chasballew))
+* Chet Bortz ([@cbortz](https://github.com/cbortz))
 
 ## Copyright and License
 

--- a/script/sync-readme-usage
+++ b/script/sync-readme-usage
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'open3'
 
-USAGE = ARGV.fetch(0)
+USAGE = ARGV.fetch(0, 'README.md')
 
 puts "Sync CLI usage in #{USAGE}"
 


### PR DESCRIPTION
## Context

When first contributing here, I ran into an issue here the README was out of sync after creating a new command. While this is mentioned in the instructions, the command given didn't produce a new output for me. Thus, the build failed.

After looking at the [failing build in TravisCI](https://travis-ci.org/aptible/aptible-cli/builds/266060557), I found that there's an [internal script](https://github.com/aptible/aptible-cli/blob/master/script/sync-readme-usage) with just that purpose: Updating the CLI usage in the readme file. It seemed clear to me that the README should be updated to reference the aforementioned script.

## Changes

- Sets a default value in README sync script
  + Default to "README.md"
  + Update `.travis.yml` to reflect this change
- Update instructions for syncing README when adding a command
  + Previously set to copy the output from an `aptible help` call
  + Instead, leverage the README usage sync script
- Updates Contributors in README