### PR TITLE
Endpoints commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,13 @@ Commands:
   aptible endpoints:database:create DATABASE                                                                                         # Create a Database Endpoint
   aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                  # Deprovision an App or Database Endpoint
   aptible endpoints:https:create [--app APP] SERVICE                                                                                 # Create an App HTTPS Endpoint
+  aptible endpoints:https:modify [--app APP] ENDPOINT_HOSTNAME                                                                       # Modify an App HTTPS Endpoint
   aptible endpoints:list [--app APP | --database DATABASE]                                                                           # List Endpoints for an App or Database
   aptible endpoints:renew [--app APP] ENDPOINT_HOSTNAME                                                                              # Renew an App Managed TLS Endpoint
   aptible endpoints:tcp:create [--app APP] SERVICE                                                                                   # Create an App TCP Endpoint
+  aptible endpoints:tcp:modify [--app APP] ENDPOINT_HOSTNAME                                                                         # Modify an App TCP Endpoint
   aptible endpoints:tls:create [--app APP] SERVICE                                                                                   # Create an App TLS Endpoint
+  aptible endpoints:tls:modify [--app APP] ENDPOINT_HOSTNAME                                                                         # Modify an App TLS Endpoint
   aptible help [COMMAND]                                                                                                             # Describe available commands or one specific command
   aptible login                                                                                                                      # Log in to Aptible
   aptible logs [--app APP | --database DATABASE]                                                                                     # Follows logs from a running app or database

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Commands:
   aptible db:tunnel HANDLE                                                                                                           # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                              # Display a database URL
   aptible deploy [OPTIONS] [VAR1=VAL1] [VAR=VAL2] ...                                                                                # Deploy an app
-  aptible domains                                                                                                                    # Print an app's current virtual domains
+  aptible domains                                                                                                                    # Print an app's current virtual domains - DEPRECATED
   aptible endpoints:database:create DATABASE                                                                                         # Create a Database Endpoint
   aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                  # Deprovision an App or Database Endpoint
   aptible endpoints:https:create [--app APP] SERVICE                                                                                 # Create an App HTTPS Endpoint

--- a/README.md
+++ b/README.md
@@ -53,9 +53,16 @@ Commands:
   aptible db:url HANDLE                                                                                                              # Display a database URL
   aptible deploy [OPTIONS] [VAR1=VAL1] [VAR=VAL2] ...                                                                                # Deploy an app
   aptible domains                                                                                                                    # Print an app's current virtual domains
+  aptible endpoints:database:create DATABASE                                                                                         # Create a Database Endpoint
+  aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                  # Deprovision an App or Database Endpoint
+  aptible endpoints:https:create [--app APP] SERVICE                                                                                 # Create an App HTTPS Endpoint
+  aptible endpoints:list [--app APP | --database DATABASE]                                                                           # List Endpoints for an App or Database
+  aptible endpoints:renew [--app APP] ENDPOINT_HOSTNAME                                                                              # Renew an App Managed TLS Endpoint
+  aptible endpoints:tcp:create [--app APP] SERVICE                                                                                   # Create an App TCP Endpoint
+  aptible endpoints:tls:create [--app APP] SERVICE                                                                                   # Create an App TLS Endpoint
   aptible help [COMMAND]                                                                                                             # Describe available commands or one specific command
   aptible login                                                                                                                      # Log in to Aptible
-  aptible logs                                                                                                                       # Follows logs from a running app or database
+  aptible logs [--app APP | --database DATABASE]                                                                                     # Follows logs from a running app or database
   aptible operation:cancel OPERATION_ID                                                                                              # Cancel a running operation
   aptible ps                                                                                                                         # Display running processes for an app - DEPRECATED
   aptible rebuild                                                                                                                    # Rebuild an app, and restart its services

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-resource', '~> 0.4.0'
-  spec.add_dependency 'aptible-api', '~> 0.9.27'
-  spec.add_dependency 'aptible-auth', '~> 0.11.13'
+  spec.add_dependency 'aptible-resource', '~> 1.0'
+  spec.add_dependency 'aptible-api', '~> 1.0'
+  spec.add_dependency 'aptible-auth', '~> 1.0'
+  spec.add_dependency 'aptible-billing', '~> 1.0'
   spec.add_dependency 'thor', '~> 0.19.1'
   spec.add_dependency 'git'
   spec.add_dependency 'term-ansicolor'

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-resource', '~> 1.0'
+  spec.add_dependency 'aptible-resource', '~> 1.0', '>= 1.0.1'
   spec.add_dependency 'aptible-api', '~> 1.0'
   spec.add_dependency 'aptible-auth', '~> 1.0'
   spec.add_dependency 'aptible-billing', '~> 1.0'

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -11,6 +11,9 @@ require_relative 'helpers/operation'
 require_relative 'helpers/environment'
 require_relative 'helpers/app'
 require_relative 'helpers/database'
+require_relative 'helpers/app_or_database'
+require_relative 'helpers/vhost'
+require_relative 'helpers/vhost/option_set_builder'
 require_relative 'helpers/tunnel'
 
 require_relative 'subcommands/apps'
@@ -26,6 +29,7 @@ require_relative 'subcommands/ssh'
 require_relative 'subcommands/backup'
 require_relative 'subcommands/operation'
 require_relative 'subcommands/inspect'
+require_relative 'subcommands/endpoints'
 
 module Aptible
   module CLI
@@ -47,6 +51,7 @@ module Aptible
       include Subcommands::Backup
       include Subcommands::Operation
       include Subcommands::Inspect
+      include Subcommands::Endpoints
 
       # Forward return codes on failures.
       def self.exit_on_failure?

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -121,8 +121,10 @@ module Aptible
       private
 
       def deprecated(msg)
-        say "DEPRECATION NOTICE: #{msg}"
-        say 'Please contact support@aptible.com with any questions.'
+        $stderr.puts yellow([
+          "DEPRECATION NOTICE: #{msg}",
+          'Please contact support@aptible.com with any questions.'
+        ].join("\n"))
       end
 
       def nag_toolbelt

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -132,6 +132,25 @@ module Aptible
           end
         end
 
+        def ensure_service(options, type)
+          app = ensure_app(options)
+          service = app.services.find { |s| s.process_type == type }
+
+          if service.nil?
+            valid_types = if app.services.empty?
+                            'NONE (deploy the app first)'
+                          else
+                            app.services.map(&:process_type).join(', ')
+                          end
+
+            raise Thor::Error, "Service with type #{type} does not " \
+                               "exist for app #{app.handle}. Valid " \
+                               "types: #{valid_types}."
+          end
+
+          service
+        end
+
         def apps_from_handle(handle, environment)
           if environment
             environment.apps

--- a/lib/aptible/cli/helpers/app_or_database.rb
+++ b/lib/aptible/cli/helpers/app_or_database.rb
@@ -1,0 +1,34 @@
+module Aptible
+  module CLI
+    module Helpers
+      module AppOrDatabase
+        include Helpers::App
+        include Helpers::Database
+
+        module ClassMethods
+          def app_or_database_options
+            app_options
+            option :database
+          end
+        end
+
+        def ensure_app_or_database(options = {})
+          if options[:app] && options[:database]
+            m = 'You must specify only one of --app and --database'
+            raise Thor::Error, m
+          end
+
+          if options[:database]
+            ensure_database(options.merge(db: options[:database]))
+          else
+            ensure_app(options)
+          end
+        end
+
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/helpers/vhost.rb
+++ b/lib/aptible/cli/helpers/vhost.rb
@@ -1,0 +1,83 @@
+module Aptible
+  module CLI
+    module Helpers
+      module Vhost
+        def explain_vhost(service, vhost)
+          say "Service: #{service.process_type}"
+          say "Hostname: #{vhost.external_host}"
+          say "Status: #{vhost.status}"
+
+          case vhost.type
+          when 'tcp', 'tls'
+            ports = if vhost.container_ports.any?
+                      vhost.container_ports.map(&:to_s).join(' ')
+                    else
+                      'all'
+                    end
+            say "Type: #{vhost.type}"
+            say "Ports: #{ports}"
+          when 'http', 'http_proxy_protocol'
+            port = vhost.container_port ? vhost.container_port : 'default'
+            say 'Type: https'
+            say "Port: #{port}"
+          end
+
+          say "Internal: #{vhost.internal}"
+
+          ip_whitelist = if vhost.ip_whitelist.any?
+                           vhost.ip_whitelist.join(' ')
+                         else
+                           'all traffic'
+                         end
+          say "IP Whitelist: #{ip_whitelist}"
+
+          say "Default Domain Enabled: #{vhost.default}"
+          say "Default Domain: #{vhost.virtual_domain}" if vhost.default
+
+          say "Managed TLS Enabled: #{vhost.acme}"
+          if vhost.acme
+            say "Managed TLS Domain: #{vhost.user_domain}"
+            say 'Managed TLS DNS Challenge Hostname: ' \
+                "#{vhost.acme_dns_challenge_host}"
+            say "Managed TLS Status: #{vhost.acme_status}"
+          end
+        end
+
+        def provision_vhost_and_explain(service, vhost)
+          op = vhost.create_operation!(type: 'provision')
+          attach_to_operation_logs(op)
+          explain_vhost(service, vhost.reload)
+          # TODO: Instructions if ACME is enabled?
+        end
+
+        def find_vhost(service_enumerator, hostname)
+          seen = []
+
+          service_enumerator.each do |service|
+            service.each_vhost do |vhost|
+              seen << vhost.external_host
+              return vhost if vhost.external_host == hostname
+            end
+          end
+
+          e = "Endpoint with hostname #{hostname} does not exist"
+          e = "#{e} (valid hostnames: #{seen.join(', ')})" if seen.any?
+          raise Thor::Error, e
+        end
+
+        def each_vhost(resource, &block)
+          return enum_for(:each_vhost, resource) unless block_given?
+
+          klass = resource.class
+          if klass == Aptible::Api::App
+            resource.each_service(&block)
+          elsif klass == Aptible::Api::Database
+            [resource.service].each(&block)
+          else
+            raise "Unexpected resource: #{klass}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/helpers/vhost/option_set_builder.rb
+++ b/lib/aptible/cli/helpers/vhost/option_set_builder.rb
@@ -1,0 +1,250 @@
+module Aptible
+  module CLI
+    module Helpers
+      module Vhost
+        class OptionSetBuilder
+          FLAGS = %i(
+            environment
+            app
+            database
+            tls
+            ports
+            port
+          ).freeze
+
+          def initialize(&block)
+            FLAGS.each { |f| instance_variable_set("@#{f}", false) }
+            instance_exec(&block) if block
+          end
+
+          def declare_options(thor)
+            thor.instance_exec(self) do |builder|
+              option :environment
+
+              if builder.app?
+                app_options
+                option(
+                  :default_domain,
+                  type: :boolean,
+                  desc: 'Whether to enable Default Domain on this Endpoint'
+                )
+
+                option(
+                  :internal,
+                  type: :boolean,
+                  desc: 'Whether to restrict this Endpoint to internal traffic'
+                )
+
+                if builder.ports?
+                  option(
+                    :ports,
+                    type: :array,
+                    desc: 'Specify a list of ports to expose on this Endpoint'
+                  )
+                end
+
+                if builder.port?
+                  option(
+                    :port,
+                    type: :numeric,
+                    desc: 'Specify a port to expose on this Endpoint'
+                  )
+                end
+              end
+
+              option(
+                :ip_whitelist,
+                type: :array,
+                desc: 'Restrict traffic to this Endpoint to a list of IP ' \
+                      'sources (addresses or CIDRs)'
+              )
+
+              if builder.tls?
+                option(
+                  :certificate_file,
+                  type: :string,
+                  desc: 'A file containing a certificate to use on this ' \
+                        'Endpoint'
+                )
+                option(
+                  :private_key_file,
+                  type: :string,
+                  desc: 'A file containing a private key to use on this ' \
+                        'Endpoint'
+                )
+
+                option(
+                  :managed_tls,
+                  type: :boolean,
+                  desc: 'Whether to enable Managed TLS on this Endpoint'
+                )
+
+                option(
+                  :managed_tls_domain,
+                  desc: 'The domain to use for Managed TLS'
+                )
+
+                option(
+                  :certificate_fingerprint,
+                  type: :string,
+                  desc: 'The fingerprint of an existing Certificate to use ' \
+                        'on this Endpoint'
+                )
+              end
+            end
+          end
+
+          def prepare(account, options)
+            options = options.dup # We're going to delete keys here
+            verify_option_conflicts(options)
+
+            params = {}
+
+            params[:ip_whitelist] = options.delete(:ip_whitelist) { [] }
+
+            params[:container_port] = options.delete(:port) if port?
+
+            if ports?
+              raw_ports = options.delete(:ports) { [] }
+              params[:container_ports] = raw_ports.map do |p|
+                begin
+                  Integer(p)
+                rescue ArgumentError
+                  m = "Invalid port: #{p}"
+                  raise Thor::Error, m
+                end
+              end
+            end
+
+            if app?
+              params[:internal] = !!options.delete(:internal) { false }
+              params[:default] = !!options.delete(:default_domain) { false }
+              options.delete(:app)
+            else
+              params[:internal] = false
+            end
+
+            process_tls(account, options, params) if tls?
+
+            options.delete(:environment)
+
+            # NOTE: This is here to ensure that specs don't test for options
+            # that are not declared. This is not expected to happen when using
+            # this.
+            raise "Unexpected options: #{options}" if options.any?
+
+            params
+          end
+
+          FLAGS.each do |f|
+            define_method("#{f}?") { instance_variable_get("@#{f}") }
+          end
+
+          private
+
+          FLAGS.each do |f|
+            define_method("#{f}!") { instance_variable_set("@#{f}", true) }
+          end
+
+          def process_tls(account, options_in, params_out)
+            # Certificate fingerprint option
+            if (fingerprint = options_in.delete(:certificate_fingerprint))
+              params_out[:certificate] = find_certificate(account, fingerprint)
+            end
+
+            # Ad-hoc certificate option
+            certificate_file = options_in.delete(:certificate_file)
+            private_key_file = options_in.delete(:private_key_file)
+
+            if certificate_file || private_key_file
+              if certificate_file.nil?
+                raise Thor::Error, "Missing #{to_flag(:certificate_file)}"
+              end
+
+              if private_key_file.nil?
+                raise Thor::Error, "Missing #{to_flag(:private_key_file)}"
+              end
+
+              opts = begin
+                       {
+                         certificate_body: File.read(certificate_file),
+                         private_key: File.read(private_key_file)
+                       }
+                     rescue StandardError => e
+                       m = 'Failed to read certificate or private key ' \
+                         "file: #{e}"
+                       raise Thor::Error, m
+                     end
+
+              params_out[:certificate] = account.create_certificate!(opts)
+            end
+
+            # ACME option
+            acme = params_out[:acme] = options_in.delete(:managed_tls) { false }
+            if acme
+              user_domain = options_in.delete(:managed_tls_domain)
+              e = "#{to_flag(:managed_tls_domain)} is required to enable " \
+                  'Managed TLS'
+              raise Thor::Error, e if user_domain.nil?
+              params_out[:user_domain] = user_domain
+            end
+          end
+
+          def find_certificate(account, fingerprint)
+            matches = []
+            account.each_certificate do |certificate|
+              if certificate.sha256_fingerprint == fingerprint
+                return certificate
+              end
+
+              if certificate.sha256_fingerprint.start_with?(fingerprint)
+                matches << certificate
+              end
+            end
+
+            matches = matches.uniq(&:sha256_fingerprint)
+
+            case matches.size
+            when 0
+              e = "No certificate matches fingerprint #{fingerprint}"
+              raise Thor::Error, e
+            when 1
+              return matches.first
+            else
+              e = 'Too many certificates match fingerprint ' \
+                  "#{fingerprint}, pass a more specific fingerprint "
+              raise Thor::Error, e
+            end
+          end
+
+          def verify_option_conflicts(options)
+            certificate_options = [
+              %i(certificate_file private_key_file),
+              %i(certificate_fingerprint),
+              %i(managed_tls managed_tls_domain),
+              %i(default_domain)
+            ]
+
+            matches = certificate_options.map do |g|
+              g.any? { |k| !!options[k] }
+            end
+
+            if matches.select { |m| !!m }.size > 1
+              selected = certificate_options.flatten.select do |o|
+                !!options[o]
+              end
+
+              flags = selected.map { |s| to_flag(s) }
+              e = "Conflicting options provided: #{flags.join(', ')}"
+              raise Thor::Error, e
+            end
+          end
+
+          def to_flag(sym)
+            "--#{sym.to_s.tr('_', '-')}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -43,8 +43,7 @@ module Aptible
             option :size, type: :numeric,
                           desc: 'DEPRECATED, use --container-size'
             define_method 'apps:scale' do |type, *more|
-              app = ensure_app(options)
-              service = app.services.find { |s| s.process_type == type }
+              service = ensure_service(options, type)
 
               container_count = options[:container_count]
               container_size = options[:container_size]
@@ -92,17 +91,6 @@ module Aptible
               if container_count.nil? && container_size.nil?
                 raise Thor::Error,
                       'Provide at least --container-count or --container-size'
-              end
-
-              if service.nil?
-                valid_types = if app.services.empty?
-                                'NONE (deploy the app first)'
-                              else
-                                app.services.map(&:process_type).join(', ')
-                              end
-                raise Thor::Error, "Service with type #{type} does not " \
-                                   "exist for app #{app.handle}. Valid " \
-                                   "types: #{valid_types}."
               end
 
               # We don't validate any parameters here: API will do that for us.

--- a/lib/aptible/cli/subcommands/domains.rb
+++ b/lib/aptible/cli/subcommands/domains.rb
@@ -9,10 +9,12 @@ module Aptible
             include Helpers::Operation
             include Helpers::App
 
-            desc 'domains', "Print an app's current virtual domains"
+            desc 'domains',
+                 "Print an app's current virtual domains - DEPRECATED"
             app_options
             option :verbose, aliases: '-v'
             def domains
+              deprecated 'This command is deprecated in favor of endpoints:list'
               app = ensure_app(options)
               print_vhosts(app) do |vhost|
                 if options[:verbose]

--- a/lib/aptible/cli/subcommands/endpoints.rb
+++ b/lib/aptible/cli/subcommands/endpoints.rb
@@ -1,0 +1,142 @@
+require 'term/ansicolor'
+require 'uri'
+
+module Aptible
+  module CLI
+    module Subcommands
+      module Endpoints
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::Operation
+            include Helpers::AppOrDatabase
+            include Helpers::Vhost
+
+            database_flags = Helpers::Vhost::OptionSetBuilder.new do
+              database!
+            end
+
+            desc 'endpoints:database:create DATABASE',
+                 'Create a Database Endpoint'
+            database_flags.declare_options(self)
+            define_method 'endpoints:database:create' do |handle|
+              database = ensure_database(options.merge(db: handle))
+              service = database.service
+              raise Thor::Error, 'Database is not provisioned' if service.nil?
+
+              vhost = service.create_vhost!(
+                type: 'tcp',
+                platform: 'elb',
+                **database_flags.prepare(database.account, options)
+              )
+
+              provision_vhost_and_explain(service, vhost)
+            end
+
+            tcp_flags = Helpers::Vhost::OptionSetBuilder.new do
+              app!
+              ports!
+            end
+
+            desc 'endpoints:tcp:create [--app APP] SERVICE',
+                 'Create an App TCP Endpoint'
+            tcp_flags.declare_options(self)
+            define_method 'endpoints:tcp:create' do |type|
+              service = ensure_service(options, type)
+
+              vhost = service.create_vhost!(
+                type: 'tcp',
+                platform: 'elb',
+                **tcp_flags.prepare(service.account, options)
+              )
+
+              provision_vhost_and_explain(service, vhost)
+            end
+
+            tls_flags = Helpers::Vhost::OptionSetBuilder.new do
+              app!
+              ports!
+              tls!
+            end
+
+            desc 'endpoints:tls:create [--app APP] SERVICE',
+                 'Create an App TLS Endpoint'
+            tls_flags.declare_options(self)
+            define_method 'endpoints:tls:create' do |type|
+              service = ensure_service(options, type)
+
+              vhost = service.create_vhost!(
+                type: 'tls',
+                platform: 'elb',
+                **tls_flags.prepare(service.account, options)
+              )
+
+              provision_vhost_and_explain(service, vhost)
+            end
+
+            https_flags = Helpers::Vhost::OptionSetBuilder.new do
+              app!
+              port!
+              tls!
+            end
+
+            desc 'endpoints:https:create [--app APP] SERVICE',
+                 'Create an App HTTPS Endpoint'
+            https_flags.declare_options(self)
+            define_method 'endpoints:https:create' do |type|
+              service = ensure_service(options, type)
+
+              vhost = service.create_vhost!(
+                type: 'http',
+                platform: 'alb',
+                **https_flags.prepare(service.account, options)
+              )
+
+              provision_vhost_and_explain(service, vhost)
+            end
+
+            desc 'endpoints:list [--app APP | --database DATABASE]',
+                 'List Endpoints for an App or Database'
+            app_or_database_options
+            define_method 'endpoints:list' do
+              resource = ensure_app_or_database(options)
+
+              first = true
+              each_vhost(resource) do |service|
+                service.each_vhost do |vhost|
+                  say '' unless first
+                  first = false
+                  explain_vhost(service, vhost)
+                end
+              end
+            end
+
+            desc 'endpoints:deprovision [--app APP | --database DATABASE] ' \
+                 'ENDPOINT_HOSTNAME', \
+                 'Deprovision an App or Database Endpoint'
+            app_or_database_options
+            define_method 'endpoints:deprovision' do |hostname|
+              resource = ensure_app_or_database(options)
+              vhost = find_vhost(each_vhost(resource), hostname)
+              op = vhost.create_operation!(type: 'deprovision')
+              attach_to_operation_logs(op)
+            end
+
+            desc 'endpoints:renew [--app APP] ENDPOINT_HOSTNAME', \
+                 'Renew an App Managed TLS Endpoint'
+            app_options
+            define_method 'endpoints:renew' do |hostname|
+              app = ensure_app(options)
+              vhost = find_vhost(app.each_service, hostname)
+              op = vhost.create_operation!(type: 'renew')
+              attach_to_operation_logs(op)
+            end
+          end
+
+          # TODO: in the longer term once we have a good API representation for
+          # it, we should include methods to update VHOSTs without having to
+          # deprovison them or use the Dashboard.
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/subcommands/endpoints.rb
+++ b/lib/aptible/cli/subcommands/endpoints.rb
@@ -11,13 +11,14 @@ module Aptible
             include Helpers::AppOrDatabase
             include Helpers::Vhost
 
-            database_flags = Helpers::Vhost::OptionSetBuilder.new do
+            database_create_flags = Helpers::Vhost::OptionSetBuilder.new do
+              create!
               database!
             end
 
             desc 'endpoints:database:create DATABASE',
                  'Create a Database Endpoint'
-            database_flags.declare_options(self)
+            database_create_flags.declare_options(self)
             define_method 'endpoints:database:create' do |handle|
               database = ensure_database(options.merge(db: handle))
               service = database.service
@@ -26,72 +27,98 @@ module Aptible
               vhost = service.create_vhost!(
                 type: 'tcp',
                 platform: 'elb',
-                **database_flags.prepare(database.account, options)
+                **database_create_flags.prepare(database.account, options)
               )
 
               provision_vhost_and_explain(service, vhost)
             end
 
-            tcp_flags = Helpers::Vhost::OptionSetBuilder.new do
+            tcp_create_flags = Helpers::Vhost::OptionSetBuilder.new do
               app!
+              create!
               ports!
             end
 
             desc 'endpoints:tcp:create [--app APP] SERVICE',
                  'Create an App TCP Endpoint'
-            tcp_flags.declare_options(self)
+            tcp_create_flags.declare_options(self)
             define_method 'endpoints:tcp:create' do |type|
-              service = ensure_service(options, type)
-
-              vhost = service.create_vhost!(
-                type: 'tcp',
-                platform: 'elb',
-                **tcp_flags.prepare(service.account, options)
+              create_app_vhost(
+                tcp_create_flags, options, type,
+                type: 'tcp', platform: 'elb'
               )
-
-              provision_vhost_and_explain(service, vhost)
             end
 
-            tls_flags = Helpers::Vhost::OptionSetBuilder.new do
+            tcp_modify_flags = Helpers::Vhost::OptionSetBuilder.new do
               app!
+              ports!
+            end
+
+            desc 'endpoints:tcp:modify [--app APP] ENDPOINT_HOSTNAME',
+                 'Modify an App TCP Endpoint'
+            tcp_modify_flags.declare_options(self)
+            define_method 'endpoints:tcp:modify' do |hostname|
+              modify_app_vhost(tcp_modify_flags, options, hostname)
+            end
+
+            tls_create_flags = Helpers::Vhost::OptionSetBuilder.new do
+              app!
+              create!
               ports!
               tls!
             end
 
             desc 'endpoints:tls:create [--app APP] SERVICE',
                  'Create an App TLS Endpoint'
-            tls_flags.declare_options(self)
+            tls_create_flags.declare_options(self)
             define_method 'endpoints:tls:create' do |type|
-              service = ensure_service(options, type)
-
-              vhost = service.create_vhost!(
-                type: 'tls',
-                platform: 'elb',
-                **tls_flags.prepare(service.account, options)
+              create_app_vhost(
+                tls_create_flags, options, type,
+                type: 'tls', platform: 'elb'
               )
-
-              provision_vhost_and_explain(service, vhost)
             end
 
-            https_flags = Helpers::Vhost::OptionSetBuilder.new do
+            tls_modify_flags = Helpers::Vhost::OptionSetBuilder.new do
               app!
+              ports!
+              tls!
+            end
+
+            desc 'endpoints:tls:modify [--app APP] ENDPOINT_HOSTNAME',
+                 'Modify an App TLS Endpoint'
+            tls_modify_flags.declare_options(self)
+            define_method 'endpoints:tls:modify' do |hostname|
+              modify_app_vhost(tls_modify_flags, options, hostname)
+            end
+
+            https_create_flags = Helpers::Vhost::OptionSetBuilder.new do
+              app!
+              create!
               port!
               tls!
             end
 
             desc 'endpoints:https:create [--app APP] SERVICE',
                  'Create an App HTTPS Endpoint'
-            https_flags.declare_options(self)
+            https_create_flags.declare_options(self)
             define_method 'endpoints:https:create' do |type|
-              service = ensure_service(options, type)
-
-              vhost = service.create_vhost!(
-                type: 'http',
-                platform: 'alb',
-                **https_flags.prepare(service.account, options)
+              create_app_vhost(
+                https_create_flags, options, type,
+                type: 'http', platform: 'alb'
               )
+            end
 
-              provision_vhost_and_explain(service, vhost)
+            https_modify_flags = Helpers::Vhost::OptionSetBuilder.new do
+              app!
+              port!
+              tls!
+            end
+
+            desc 'endpoints:https:modify [--app APP] ENDPOINT_HOSTNAME',
+                 'Modify an App HTTPS Endpoint'
+            https_modify_flags.declare_options(self)
+            define_method 'endpoints:https:modify' do |hostname|
+              modify_app_vhost(https_modify_flags, options, hostname)
             end
 
             desc 'endpoints:list [--app APP | --database DATABASE]',
@@ -130,11 +157,25 @@ module Aptible
               op = vhost.create_operation!(type: 'renew')
               attach_to_operation_logs(op)
             end
-          end
 
-          # TODO: in the longer term once we have a good API representation for
-          # it, we should include methods to update VHOSTs without having to
-          # deprovison them or use the Dashboard.
+            no_commands do
+              def create_app_vhost(flags, options, process_type, **attrs)
+                service = ensure_service(options, process_type)
+                vhost = service.create_vhost!(
+                  **flags.prepare(service.account, options),
+                  **attrs
+                )
+                provision_vhost_and_explain(service, vhost)
+              end
+
+              def modify_app_vhost(flags, options, hostname)
+                app = ensure_app(options)
+                vhost = find_vhost(each_vhost(app), hostname)
+                vhost.update!(**flags.prepare(vhost.service.account, options))
+                provision_vhost_and_explain(vhost.service, vhost)
+              end
+            end
+          end
         end
       end
     end

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -7,24 +7,13 @@ module Aptible
         def self.included(thor)
           thor.class_eval do
             include Helpers::Operation
-            include Helpers::App
-            include Helpers::Database
+            include Helpers::AppOrDatabase
 
-            desc 'logs', 'Follows logs from a running app or database'
-            app_options
-            option :database
+            desc 'logs [--app APP | --database DATABASE]',
+                 'Follows logs from a running app or database'
+            app_or_database_options
             def logs
-              if options[:app] && options[:database]
-                m = 'You must specify only one of --app and --database'
-                raise Thor::Error, m
-              end
-
-              resource = \
-                if options[:database]
-                  ensure_database(options.merge(db: options[:database]))
-                else
-                  ensure_app(options)
-                end
+              resource = ensure_app_or_database(options)
 
               unless resource.status == 'provisioned'
                 raise Thor::Error, 'Unable to retrieve logs. ' \

--- a/spec/aptible/cli/helpers/vhost_spec.rb
+++ b/spec/aptible/cli/helpers/vhost_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Helpers::Vhost do
+  subject { Class.new.send(:include, described_class).new }
+
+  describe '#explain_vhost' do
+    let(:lines) { [] }
+    before { allow(subject).to receive(:say) { |m| lines << m } }
+
+    it 'explains a VHOST' do
+      service = Fabricate(:service, process_type: 'web')
+      vhost = Fabricate(
+        :vhost,
+        service: service,
+        external_host: 'foo.io',
+        status: 'provisioned',
+        type: 'http_proxy_protocol',
+        internal: false,
+        ip_whitelist: [],
+        default: false,
+        acme: false
+      )
+      subject.explain_vhost(service, vhost)
+
+      expected = [
+        'Service: web',
+        'Hostname: foo.io',
+        'Status: provisioned',
+        'Type: https',
+        'Port: default',
+        'Internal: false',
+        'IP Whitelist: all traffic',
+        'Default Domain Enabled: false',
+        'Managed TLS Enabled: false'
+      ]
+      expect(lines).to eq(expected)
+    end
+
+    it 'explains a failed VHOST' do
+      vhost = Fabricate(:vhost, status: 'provision_failed')
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Status: provision_failed')
+    end
+
+    it 'explains an internal VHOST' do
+      vhost = Fabricate(:vhost, internal: true)
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Internal: true')
+    end
+
+    it 'explains a default VHOST' do
+      vhost = Fabricate(:vhost, default: true, virtual_domain: 'qux.io')
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Default Domain Enabled: true')
+      expect(lines).to include('Default Domain: qux.io')
+    end
+
+    it 'explains a TLS VHOST' do
+      vhost = Fabricate(:vhost, type: 'tls')
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Type: tls')
+      expect(lines).to include('Ports: all')
+    end
+
+    it 'explains a TCP VHOST' do
+      vhost = Fabricate(:vhost, type: 'tcp')
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Type: tcp')
+      expect(lines).to include('Ports: all')
+    end
+
+    it 'explains a VHOST with a container port' do
+      vhost = Fabricate(:vhost, type: 'http_proxy_protocol', container_port: 12)
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Port: 12')
+    end
+
+    it 'explains a VHOST with container ports' do
+      vhost = Fabricate(:vhost, type: 'tls', container_ports: [12, 34])
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Ports: 12 34')
+    end
+
+    it 'explains a VHOST with IP Filtering' do
+      vhost = Fabricate(:vhost, ip_whitelist: %w(1.1.1.1/1 2.2.2.2/2))
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('IP Whitelist: 1.1.1.1/1 2.2.2.2/2')
+    end
+
+    it 'explains a VHOST with Managed TLS' do
+      vhost = Fabricate(
+        :vhost,
+        acme: true,
+        user_domain: 'foo.io',
+        acme_dns_challenge_host: 'dns.qux.io',
+        acme_status: 'ready'
+      )
+      subject.explain_vhost(vhost.service, vhost)
+      expect(lines).to include('Managed TLS Enabled: true')
+      expect(lines).to include('Managed TLS Domain: foo.io')
+      expect(lines).to include('Managed TLS DNS Challenge Hostname: dns.qux.io')
+      expect(lines).to include('Managed TLS Status: ready')
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -26,7 +26,7 @@ describe Aptible::CLI::Agent do
 
   let!(:account) { Fabricate(:account) }
   let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
-  let!(:service) { Fabricate(:service, app: app) }
+  let!(:service) { Fabricate(:service, app: app, process_type: 'web') }
   let(:op) { Fabricate(:operation, status: 'succeeded', resource: app) }
 
   describe '#apps:scale' do

--- a/spec/aptible/cli/subcommands/endpoints_spec.rb
+++ b/spec/aptible/cli/subcommands/endpoints_spec.rb
@@ -1,0 +1,469 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  let!(:a1) { Fabricate(:account, handle: 'foo') }
+  let!(:a2) { Fabricate(:account, handle: 'bar') }
+
+  let(:token) { double 'token' }
+
+  before do
+    allow(subject).to receive(:fetch_token) { token }
+    allow(Aptible::Api::Account).to receive(:all).with(token: token)
+      .and_return([a1, a2])
+  end
+
+  def expect_create_certificate(account, options)
+    expect(account).to receive(:create_certificate!).with(
+      hash_including(options)
+    ) do |args|
+      Fabricate(:certificate, account: account, **args)
+    end
+  end
+
+  def expect_create_vhost(service, options)
+    expect(service).to receive(:create_vhost!).with(
+      hash_including(options)
+    ) do |args|
+      Fabricate(:vhost, service: service, **args).tap do |v|
+        expect_operation(v, 'provision')
+        expect(v).to receive(:reload).and_return(v)
+        expect(subject).to receive(:explain_vhost).with(service, v)
+      end
+    end
+  end
+
+  def expect_operation(vhost, type)
+    expect(vhost).to receive(:create_operation!).with(type: type) do
+      Fabricate(:operation).tap do |o|
+        expect(subject).to receive(:attach_to_operation_logs).with(o)
+      end
+    end
+  end
+
+  context 'Database Endpoints' do
+    def stub_options(**opts)
+      allow(subject).to receive(:options).and_return(opts)
+    end
+
+    let!(:db) { Fabricate(:database, handle: 'mydb', account: a1) }
+
+    before do
+      allow(Aptible::Api::Database).to receive(:all).with(token: token)
+        .and_return([db])
+      allow(db).to receive(:class).and_return(Aptible::Api::Database)
+      stub_options
+    end
+
+    describe 'endpoints:database:create' do
+      it 'fails if the DB does not exist' do
+        expect { subject.send('endpoints:database:create', 'some') }
+          .to raise_error(/could not find database some/im)
+      end
+
+      it 'fails if the DB is not in the account' do
+        stub_options(environment: 'bar')
+        expect { subject.send('endpoints:database:create', 'mydb') }
+          .to raise_error(/could not find database mydb/im)
+      end
+
+      it 'creates a new Endpoint' do
+        expect_create_vhost(
+          db.service,
+          type: 'tcp',
+          platform: 'elb',
+          internal: false,
+          ip_whitelist: []
+        )
+        subject.send('endpoints:database:create', 'mydb')
+      end
+
+      it 'creates a new Endpoint with IP Filtering' do
+        expect_create_vhost(db.service, ip_whitelist: %w(1.1.1.1))
+        stub_options(ip_whitelist: %w(1.1.1.1))
+        subject.send('endpoints:database:create', 'mydb')
+      end
+    end
+
+    describe 'endpoints:list' do
+      it 'lists Endpoints' do
+        lines = []
+        allow(subject).to receive(:say) { |m| lines << m }
+
+        s = Fabricate(:service, database: db)
+        v1 = Fabricate(:vhost, service: s)
+        v2 = Fabricate(:vhost, service: s)
+
+        stub_options(database: db.handle)
+        subject.send('endpoints:list')
+
+        expect(lines).to include("Hostname: #{v1.external_host}")
+        expect(lines).to include("Hostname: #{v2.external_host}")
+
+        expect(lines[0]).not_to eq("\n")
+        expect(lines[-1]).not_to eq("\n")
+      end
+    end
+
+    describe 'endpoints:deprovison' do
+      it 'deprovisions an Endpoint' do
+        s = Fabricate(:service, database: db)
+        Fabricate(:vhost, service: s)
+        v2 = Fabricate(:vhost, service: s)
+
+        stub_options(database: db.handle)
+
+        expect_operation(v2, 'deprovision')
+        subject.send('endpoints:deprovision', v2.external_host)
+      end
+
+      it 'fails if the Endpoint does not exist' do
+        stub_options(database: db.handle)
+
+        expect { subject.send('endpoints:deprovision', 'foo.io') }
+          .to raise_error(/endpoint.*foo\.io.*does not exist/im)
+      end
+    end
+  end
+
+  context 'App Endpoints' do
+    def stub_options(**opts)
+      base = { app: app.handle }
+      allow(subject).to receive(:options).and_return(base.merge(opts))
+    end
+
+    let!(:app) { Fabricate(:app, handle: 'myapp', account: a1) }
+    let!(:service) { Fabricate(:service, app: app, process_type: 'web') }
+
+    before do
+      allow(Aptible::Api::App).to receive(:all).with(token: token)
+        .and_return([app])
+      allow(app).to receive(:class).and_return(Aptible::Api::App)
+      stub_options
+    end
+
+    shared_examples 'shared app vhost examples' do |method|
+      context 'App Vhost Options' do
+        it 'fails if the app does not exist' do
+          stub_options(app: 'foo')
+          expect { subject.send(method, 'foo') }
+            .to raise_error(/could not find app/im)
+        end
+
+        it 'fails if the service does not exist' do
+          expect { subject.send(method, 'foo') }
+            .to raise_error(/service.*does not exist/im)
+        end
+
+        it 'creates an internal Endpoint' do
+          expect_create_vhost(service, internal: true)
+          stub_options(internal: true)
+          subject.send(method, 'web')
+        end
+
+        it 'creates an Endpoint with IP Filtering' do
+          expect_create_vhost(service, ip_whitelist: %w(1.1.1.1))
+          stub_options(ip_whitelist: %w(1.1.1.1))
+          subject.send(method, 'web')
+        end
+
+        it 'creates a default Endpoint' do
+          expect_create_vhost(service, default: true)
+          stub_options(default_domain: true)
+          subject.send(method, 'web')
+        end
+      end
+    end
+
+    shared_examples 'shared tcp vhost examples' do |method|
+      context 'TCP VHOST Options' do
+        it 'creates an Endpoint with Ports' do
+          expect_create_vhost(service, container_ports: [10, 20])
+          stub_options(ports: %w(10 20))
+          subject.send(method, 'web')
+        end
+
+        it 'raises an error if the ports are invalid' do
+          stub_options(ports: %w(foo))
+          expect { subject.send(method, 'web') }
+            .to raise_error(/invalid port: foo/im)
+        end
+      end
+    end
+
+    shared_examples 'shared tls vhost examples' do |method|
+      context 'TLS Vhost Options' do
+        it 'creates an Endpoint with a new Certificate' do
+          expect_create_certificate(
+            a1,
+            certificate_body: 'the cert',
+            private_key: 'the key'
+          )
+
+          expect_create_vhost(
+            service,
+            certificate: an_instance_of(StubCertificate),
+            acme: false,
+            default: false
+          )
+
+          Dir.mktmpdir do |d|
+            cert, key = %w(cert key).map { |f| File.join(d, f) }
+            File.write(cert, 'the cert')
+            File.write(key, 'the key')
+            stub_options(certificate_file: cert, private_key_file: key)
+            subject.send(method, 'web')
+          end
+        end
+
+        it 'fails if certificate file is not provided' do
+          stub_options(private_key_file: 'foo')
+          expect { subject.send(method, 'web') }
+            .to raise_error(/missing --certificate-file/im)
+        end
+
+        it 'fails if private key file is not provided' do
+          stub_options(certificate_file: 'foo')
+          expect { subject.send(method, 'web') }
+            .to raise_error(/missing --private-key-file/im)
+        end
+
+        it 'fails if a file is unreadable' do
+          Dir.mktmpdir do |d|
+            cert, key = %w(cert key).map { |f| File.join(d, f) }
+            stub_options(certificate_file: cert, private_key_file: key)
+            expect { subject.send(method, 'web') }
+              .to raise_error(/failed to read certificate or private key/im)
+          end
+        end
+
+        it 'creates an Endpoint with an existing Certificate (exact match)' do
+          c = Fabricate(:certificate, account: a1)
+          stub_options(certificate_fingerprint: c.sha256_fingerprint)
+
+          expect_create_vhost(
+            service,
+            certificate: c,
+            acme: false,
+            default: false
+          )
+
+          subject.send(method, 'web')
+        end
+
+        it 'creates an Endpoint with an existing Certificate (one match)' do
+          c = Fabricate(:certificate, account: a1)
+          Fabricate(:certificate, account: a1)
+
+          stub_options(certificate_fingerprint: c.sha256_fingerprint[0..5])
+          expect_create_vhost(service, certificate: c)
+          subject.send(method, 'web')
+        end
+
+        it 'creates an Endpoint with an existing Certificate (dupe matches)' do
+          c1 = Fabricate(:certificate, account: a1)
+          Fabricate(
+            :certificate,
+            account: a1,
+            sha256_fingerprint: c1.sha256_fingerprint
+          )
+
+          stub_options(certificate_fingerprint: c1.sha256_fingerprint[0..5])
+          expect_create_vhost(service, certificate: c1)
+          subject.send(method, 'web')
+        end
+
+        it 'creates an Endpoint with Managed TLS' do
+          expect_create_vhost(
+            service,
+            acme: true,
+            user_domain: 'foo.io'
+          )
+
+          stub_options(managed_tls: true, managed_tls_domain: 'foo.io')
+          subject.send(method, 'web')
+        end
+
+        it 'requires a domain for Managed TLS' do
+          stub_options(managed_tls: true)
+          expect { subject.send(method, 'web') }
+            .to raise_error(/--managed-tls-domain/im)
+        end
+
+        it 'fails if the certificate does not exist' do
+          Fabricate(:certificate, account: a1)
+          c2 = Fabricate(:certificate, account: a2)
+
+          stub_options(certificate_fingerprint: c2.sha256_fingerprint)
+          expect { subject.send(method, 'web') }
+            .to raise_error(/no certificate matches fingerprint/im)
+        end
+
+        it 'fails if too many certificates match' do
+          Fabricate(:certificate, account: a1, sha256_fingerprint: 'fooA')
+          Fabricate(:certificate, account: a1, sha256_fingerprint: 'fooB')
+          stub_options(certificate_fingerprint: 'foo')
+          expect { subject.send(method, 'web') }
+            .to raise_error(/too many certificates match fingerprint/im)
+        end
+
+        it 'fails if conflicting options are given (ACME, Cert)' do
+          stub_options(certificate_file: 'foo', managed_tls: true)
+          expect { subject.send(method, 'web') }
+            .to raise_error(/conflicting options.*file.*managed/im)
+        end
+
+        it 'fails if conflicting options are given (ACME Domain, Cert)' do
+          stub_options(certificate_file: 'foo', managed_tls_domain: 'bar')
+          expect { subject.send(method, 'web') }
+            .to raise_error(/conflicting options.*file.*managed/im)
+        end
+
+        it 'fails if conflicting options are given (ACME, Fingerprint)' do
+          stub_options(certificate_fingerprint: 'foo', managed_tls: true)
+          expect { subject.send(method, 'web') }
+            .to raise_error(/conflicting options.*finger.*managed/im)
+        end
+
+        it 'fails if conflicting options are given (Cert, Fingerprint)' do
+          stub_options(certificate_file: 'foo', certificate_fingerprint: 'foo')
+          expect { subject.send(method, 'web') }
+            .to raise_error(/conflicting options.*file.*finger/im)
+        end
+
+        it 'fails if conflicting options are given (ACME, Default)' do
+          stub_options(managed_tls: true, default_domain: true)
+          expect { subject.send(method, 'web') }
+            .to raise_error(/conflicting options.*managed.*default/im)
+        end
+      end
+    end
+
+    describe 'endpoints:tcp:create' do
+      include_examples 'shared app vhost examples', 'endpoints:tcp:create'
+      include_examples 'shared tcp vhost examples', 'endpoints:tcp:create'
+
+      it 'creates a TCP Endpoint' do
+        expect_create_vhost(
+          service,
+          type: 'tcp',
+          platform: 'elb',
+          internal: false,
+          default: false,
+          ip_whitelist: [],
+          container_ports: []
+        )
+
+        subject.send('endpoints:tcp:create', 'web')
+      end
+    end
+
+    describe 'endpoints:tls:create' do
+      m = 'endpoints:tls:create'
+      include_examples 'shared app vhost examples', m
+      include_examples 'shared tcp vhost examples', m
+      include_examples 'shared tls vhost examples', m
+
+      it 'creates a TLS Endpoint' do
+        expect_create_vhost(
+          service,
+          type: 'tls',
+          platform: 'elb',
+          internal: false,
+          default: false,
+          ip_whitelist: [],
+          container_ports: []
+        )
+        subject.send(m, 'web')
+      end
+    end
+
+    describe 'endpoints:https:create' do
+      m = 'endpoints:https:create'
+      include_examples 'shared app vhost examples', m
+      include_examples 'shared tls vhost examples', m
+
+      it 'creates a HTTP Endpoint' do
+        expect_create_vhost(
+          service,
+          type: 'http',
+          platform: 'alb',
+          internal: false,
+          default: false,
+          ip_whitelist: [],
+          container_port: nil
+        )
+        subject.send(m, 'web')
+      end
+
+      it 'creates an Endpoint with a container Port' do
+        expect_create_vhost(service, container_port: 10)
+        stub_options(port: 10)
+        subject.send(m, 'web')
+      end
+    end
+
+    describe 'endpoints:list' do
+      it 'lists Endpoints across services' do
+        lines = []
+        allow(subject).to receive(:say) { |m| lines << m }
+
+        s1 = Fabricate(:service, app: app)
+        v1 = Fabricate(:vhost, service: s1)
+
+        s2 = Fabricate(:service, app: app)
+        v2 = Fabricate(:vhost, service: s2)
+        v3 = Fabricate(:vhost, service: s2)
+
+        subject.send('endpoints:list')
+
+        expect(lines).to include("Hostname: #{v1.external_host}")
+        expect(lines).to include("Hostname: #{v2.external_host}")
+        expect(lines).to include("Hostname: #{v3.external_host}")
+
+        expect(lines[0]).not_to eq("\n")
+        expect(lines[-1]).not_to eq("\n")
+      end
+    end
+
+    describe 'endpoints:deprovison' do
+      it 'deprovisions an Endpoint' do
+        s1 = Fabricate(:service, app: app)
+        Fabricate(:vhost, service: s1)
+
+        s2 = Fabricate(:service, app: app)
+        v2 = Fabricate(:vhost, service: s2)
+        Fabricate(:vhost, service: s2)
+
+        expect_operation(v2, 'deprovision')
+        subject.send('endpoints:deprovision', v2.external_host)
+      end
+
+      it 'fails if the Endpoint does not exist' do
+        s1 = Fabricate(:service, app: app)
+        Fabricate(:vhost, service: s1, external_host: 'qux.io')
+
+        expect { subject.send('endpoints:deprovision', 'foo.io') }
+          .to raise_error(/endpoint.*foo\.io.*does not exist.*qux\.io/im)
+      end
+    end
+
+    describe 'endpoints:renew' do
+      it 'renews an Endpoint' do
+        s1 = Fabricate(:service, app: app)
+        Fabricate(:vhost, service: s1)
+
+        s2 = Fabricate(:service, app: app)
+        v2 = Fabricate(:vhost, service: s2)
+        Fabricate(:vhost, service: s2)
+
+        expect_operation(v2, 'renew')
+        subject.send('endpoints:renew', v2.external_host)
+      end
+
+      it 'fails if the Endpoint does not exist' do
+        expect { subject.send('endpoints:deprovision', 'foo.io') }
+          .to raise_error(/endpoint.*foo\.io.*does not exist/im)
+      end
+    end
+  end
+end

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,4 +1,9 @@
-class StubAccount < OpenStruct; end
+class StubAccount < OpenStruct
+  def each_certificate(&block)
+    return enum_for(:each_certificate) if block.nil?
+    certificates.each(&block)
+  end
+end
 
 Fabricator(:account, from: :stub_account) do
   bastion_host 'localhost'
@@ -8,4 +13,5 @@ Fabricator(:account, from: :stub_account) do
 
   apps { [] }
   databases { [] }
+  certificates { [] }
 end

--- a/spec/fabricators/app_fabricator.rb
+++ b/spec/fabricators/app_fabricator.rb
@@ -2,6 +2,11 @@ class StubApp < OpenStruct
   def vhosts
     services.map(&:vhosts).flatten
   end
+
+  def each_service(&block)
+    return enum_for(:each_service) if block.nil?
+    services.each(&block)
+  end
 end
 
 Fabricator(:app, from: :stub_app) do

--- a/spec/fabricators/certificate_fabricator.rb
+++ b/spec/fabricators/certificate_fabricator.rb
@@ -1,0 +1,11 @@
+class StubCertificate < OpenStruct; end
+
+Fabricator(:certificate, from: :stub_certificate) do
+  account
+
+  sha256_fingerprint do
+    Fabricate.sequence(:sha256) { |i| Digest::SHA256.hexdigest(i.to_s) }
+  end
+
+  after_create { |cert| cert.account.certificates << cert }
+end

--- a/spec/fabricators/database_fabricator.rb
+++ b/spec/fabricators/database_fabricator.rb
@@ -5,17 +5,26 @@ class StubDatabase < OpenStruct
 end
 
 Fabricator(:database, from: :stub_database) do
+  transient :service
+
   type 'postgresql'
   handle do |attrs|
     Fabricate.sequence(:database) { |i| "#{attrs[:type]}-#{i}" }
   end
+
   passphrase 'password'
   status 'provisioned'
   connection_url 'postgresql://aptible:password@10.252.1.125:49158/db'
   account
+  service { nil }
 
   backups { [] }
   database_credentials { [] }
 
-  after_create { |database| database.account.databases << database }
+  after_create do |database, transients|
+    database.account.databases << database
+    database.service = transients[:service] || Fabricate(
+      :service, app: nil, database: database
+    )
+  end
 end

--- a/spec/fabricators/service_fabricator.rb
+++ b/spec/fabricators/service_fabricator.rb
@@ -1,9 +1,31 @@
-class StubService < OpenStruct; end
+class StubService < OpenStruct
+  def each_vhost(&block)
+    return enum_for(:each_vhost) if block.nil?
+    vhosts.each(&block)
+  end
+end
 
 Fabricator(:service, from: :stub_service) do
+  transient :app, :database
+
   process_type 'web'
-  app
   vhosts { [] }
 
-  after_create { |service| service.app.services << service }
+  after_create do |service, transients|
+    if transients[:app]
+      service.app = transients[:app]
+    elsif transients[:database]
+      service.database = transients[:database]
+    else
+      service.app = Fabricate(:app)
+    end
+
+    if service.app
+      service.app.services << service
+      service.account = service.app.account
+    else
+      service.database.service = service
+      service.account = service.database.account
+    end
+  end
 end

--- a/spec/fabricators/vhost_fabricator.rb
+++ b/spec/fabricators/vhost_fabricator.rb
@@ -1,9 +1,12 @@
 class StubVhost < OpenStruct; end
 
 Fabricator(:vhost, from: :stub_vhost) do
-  virtual_domain 'domain1'
-  external_host 'host1'
   service
+
+  external_host { Fabricate.sequence(:external_host) { |i| "host#{i}" } }
+  virtual_domain { Fabricate.sequence(:virtual_domain) { |i| "domain#{i}" } }
+  ip_whitelist { [] }
+  container_ports { [] }
 
   after_create { |vhost| vhost.service.vhosts << vhost }
 end


### PR DESCRIPTION
Add Endpoint management commands

This adds new Endpoint management commands:

```
aptible endpoints:database:create DATABASE
aptible endpoints:deprovision ENDPOINT_HOSTNAME
aptible endpoints:https:create SERVICE
aptible endpoints:list
aptible endpoints:renew ENDPOINT_HOSTNAME
aptible endpoints:tcp:create SERVICE
aptible endpoints:tls:create SERVICE
```

These commands can be used to create new Endpoints (including the 2 step
process for ACME Endpoints), list them, and delete them.

--

A few notable changes here:

- VHOSTs have a fairly complex set of options, so I've opted to have an
  "options-builder" to both declare options and parse them. The main
  benefit is that we can test for leftover options we did not expect,
  but were given. In turn, this makes our specs much more robust against
  typos / passing an option that was not expected (this came up in
  #233). Broadly speaking, testing support is something we might want
  our CLI toolkit to provide, so this might become un-necessary if /
  when we finally move off of Thor.
- I've opted to include some important options in the help text. There
  is obviously not enough space for everything, but this should at the
  very least cover basic usage.
- I have not added a command to upload a certificate (at least not yet),
  but a certificate *can* be provided implicitly when creating the
  Endpoint (by passing a certificate file and key). An existing
  certificate can be reused by providing its SHA-256 fingerprint (which
  I think is superior to providing an opaque Aptible ID).

---

cc @fancyremarker 