### PR TITLE
Add a `aptible services` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Commands:
   aptible ps                                                                                                                         # Display running processes for an app - DEPRECATED
   aptible rebuild                                                                                                                    # Rebuild an app, and restart its services
   aptible restart                                                                                                                    # Restart all services associated with an app
+  aptible services                                                                                                                   # List Services for an App
   aptible ssh [COMMAND]                                                                                                              # Run a command against an app
   aptible version                                                                                                                    # Print Aptible CLI version
 ```

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -25,6 +25,7 @@ require_relative 'subcommands/ps'
 require_relative 'subcommands/rebuild'
 require_relative 'subcommands/deploy'
 require_relative 'subcommands/restart'
+require_relative 'subcommands/services'
 require_relative 'subcommands/ssh'
 require_relative 'subcommands/backup'
 require_relative 'subcommands/operation'
@@ -47,6 +48,7 @@ module Aptible
       include Subcommands::Rebuild
       include Subcommands::Deploy
       include Subcommands::Restart
+      include Subcommands::Services
       include Subcommands::SSH
       include Subcommands::Backup
       include Subcommands::Operation

--- a/lib/aptible/cli/subcommands/services.rb
+++ b/lib/aptible/cli/subcommands/services.rb
@@ -1,0 +1,30 @@
+module Aptible
+  module CLI
+    module Subcommands
+      module Services
+        def self.included(thor)
+          thor.class_eval do
+            include Helpers::App
+
+            desc 'services', 'List Services for an App'
+            app_options
+            def services
+              app = ensure_app(options)
+
+              first = true
+              app.each_service do |service|
+                say '' unless first
+                first = false
+
+                say "Service: #{service.process_type}"
+                say "Command: #{service.command || 'CMD'}"
+                say "Container Count: #{service.container_count}"
+                say "Container Size: #{service.container_memory_limit_mb}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/services_spec.rb
+++ b/spec/aptible/cli/subcommands/services_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Agent do
+  let(:token) { double 'token' }
+  let(:app) { Fabricate(:app) }
+
+  let(:lines) { [] }
+
+  before do
+    allow(subject).to receive(:fetch_token) { token }
+    allow(Aptible::Api::App).to receive(:all).with(token: token)
+      .and_return([app])
+    allow(subject).to receive(:options).and_return(app: app.handle)
+
+    allow(subject).to receive(:say) { |m| lines << m }
+  end
+
+  it 'lists a CMD service' do
+    Fabricate(:service, app: app, process_type: 'cmd', command: nil)
+    subject.send('services')
+
+    expect(lines).to include('Service: cmd')
+    expect(lines).to include('Command: CMD')
+  end
+
+  it 'lists a service with command' do
+    Fabricate(:service, app: app, process_type: 'cmd', command: 'foobar')
+    subject.send('services')
+
+    expect(lines).to include('Service: cmd')
+    expect(lines).to include('Command: foobar')
+  end
+
+  it 'lists container size' do
+    Fabricate(:service, app: app, container_memory_limit_mb: 1024)
+    subject.send('services')
+
+    expect(lines).to include('Container Size: 1024')
+  end
+
+  it 'lists container count' do
+    Fabricate(:service, app: app, container_count: 3)
+    subject.send('services')
+
+    expect(lines).to include('Container Count: 3')
+  end
+
+  it 'lists multiple services' do
+    Fabricate(:service, app: app, process_type: 'foo')
+    Fabricate(:service, app: app, process_type: 'bar')
+    subject.send('services')
+
+    expect(lines).to include('Service: foo')
+    expect(lines).to include('Service: bar')
+  end
+end


### PR DESCRIPTION
This command lists services for an app, including their command and
scale.

---

cc @fancyremarker @UserNotFound 

Open question here: do we want to warn when there are no services for an app (because it was never deployed), or keep the output consistent? (this would probably be worth a more generic and concerted effort to update warnings throughout the CLI)