### PR TITLE
db:create - add support for --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Commands:
   aptible config:unset                                                                                                               # Alias for config:rm
   aptible db:backup HANDLE                                                                                                           # Backup a database
   aptible db:clone SOURCE DEST                                                                                                       # Clone a database to create a new one
-  aptible db:create HANDLE[--type TYPE] [--container-size SIZE_MB] [--size SIZE_GB]                                                  # Create a new database
+  aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--size SIZE_GB]                             # Create a new database
   aptible db:deprovision HANDLE                                                                                                      # Deprovision a database
   aptible db:dump HANDLE                                                                                                             # Dump a remote database to file
   aptible db:execute HANDLE SQL_FILE                                                                                                 # Executes sql against a database
@@ -51,6 +51,7 @@ Commands:
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                                              # Restart a database
   aptible db:tunnel HANDLE                                                                                                           # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                              # Display a database URL
+  aptible db:versions                                                                                                                # List available database versions
   aptible deploy [OPTIONS] [VAR1=VAL1] [VAR=VAL2] ...                                                                                # Deploy an app
   aptible domains                                                                                                                    # Print an app's current virtual domains - DEPRECATED
   aptible endpoints:database:create DATABASE                                                                                         # Create a Database Endpoint

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -115,6 +115,20 @@ module Aptible
           raise Thor::Error, "#{err}, valid credential types: #{valid}"
         end
 
+        def find_database_image(type, version)
+          available_versions = []
+
+          Aptible::Api::DatabaseImage.all(token: fetch_token).each do |i|
+            next unless i.type == type
+            return i if i.version == version
+            available_versions << i.version
+          end
+
+          err = "No Database Image of type #{type} with version #{version}"
+          err = "#{err}, valid versions: #{available_versions.join(' ')}"
+          raise Thor::Error, err
+        end
+
         def render_database(database, account)
           Formatter.render(Renderer.current) do |root|
             root.keyed_object('connection_url') do |node|

--- a/spec/fabricators/database_image_fabricator.rb
+++ b/spec/fabricators/database_image_fabricator.rb
@@ -1,0 +1,17 @@
+class StubDatabaseImage < OpenStruct
+end
+
+Fabricator(:database_image, from: :stub_database_image) do
+  type { 'postgresql' }
+  version { '9.4' }
+
+  after_create do |image|
+    if image.description.nil?
+      image.description = "#{image.type} #{image.version}"
+    end
+
+    if image.docker_repo.nil?
+      image.docker_repo = "aptible/#{image.type}:#{image.version}"
+    end
+  end
+end

--- a/spec/fabricators/operation_fabricator.rb
+++ b/spec/fabricators/operation_fabricator.rb
@@ -3,4 +3,5 @@ class StubOperation < OpenStruct; end
 Fabricator(:operation, from: :stub_operation) do
   status 'queued'
   resource { Fabricate(:app) }
+  errors { Aptible::Resource::Errors.new }
 end


### PR DESCRIPTION
This allows customers to specify a specific Database Image (i.e.
version) when creating a new Database via the CLI.

The db:images command also allows listing available Database Images.

---

This builds upon #241, for the `db:images` command.

See https://github.com/aptible/api.aptible.com/pull/582 for the backend changes

Post release, we should make sure to update the documentation for `db:create` to reference `db:images`.

cc @fancyremarker @UserNotFound 