### PR TITLE
Do not colorize logs without a TTY

### DIFF
--- a/lib/aptible/cli.rb
+++ b/lib/aptible/cli.rb
@@ -9,7 +9,7 @@ require 'aptible/cli/resource_formatter'
 
 module Aptible
   module CLI
-    class LogFormatter
+    class TtyLogFormatter
       include Term::ANSIColor
 
       def call(severity, _, _, msg)
@@ -34,9 +34,21 @@ module Aptible
       end
     end
 
+    class PlainLogFormatter
+      def call(_, _, _, msg)
+        "#{msg}\n"
+      end
+    end
+
     def self.logger
+      formatter_klass = if $stderr.tty?
+                          TtyLogFormatter
+                        else
+                          PlainLogFormatter
+                        end
+
       @logger ||= Logger.new($stderr).tap do |l|
-        l.formatter = LogFormatter.new
+        l.formatter = formatter_klass.new
       end
     end
   end

--- a/spec/aptible/cli_spec.rb
+++ b/spec/aptible/cli_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Aptible::CLI do
-  describe described_class::LogFormatter do
+  describe described_class::TtyLogFormatter do
     subject do
       Logger.new(File.open(File::NULL, 'w')).tap do |l|
         l.formatter = described_class.new


### PR DESCRIPTION
We have at least one customer parsing the output of `db:tunnel`, and
colorizing logs broke their integration, so let's fix this here.

(that said, we should probably consider better scriptability on
`db:tunnel`, the output right now is not even formatted / available as
JSON, and broadly speaking the command does not make it super easy to
access it)

---

cc @fancyremarker 