### PR TITLE
deploy / config:set reject lonely strings

### DIFF
--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -164,6 +164,7 @@ module Aptible
           Hash[args.map do |arg|
             k, v = arg.split('=', 2)
             validate_env_key!(k)
+            validate_env_pair!(k, v)
             [k, v]
           end]
         end
@@ -173,6 +174,11 @@ module Aptible
           # May 2017 (> 3 years of Aptible!), there are only 2 such cases, both
           # of which are indeed mispelled options.
           raise Thor::Error, "Invalid argument: #{k}" if k.start_with?('-')
+        end
+
+        def validate_env_pair!(k, v)
+          # Nil values
+          raise Thor::Error, "Invalid argument: #{k}" if v.nil?
         end
 
         private

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -126,6 +126,13 @@ describe Aptible::CLI::Agent do
           .to raise_error(/invalid argument/im)
       end
 
+      it 'rejects arguments without =' do
+        stub_options
+
+        expect { subject.deploy('foobar') }
+          .to raise_error(/invalid argument/im)
+      end
+
       it 'allows redundant command line arguments' do
         stub_options(docker_image: 'foobar')
 


### PR DESCRIPTION
`aptible deploy foo` is most likely a user error. If the user intends to
unset the variable, they can always use `aptible deploy foo=`.

---

See: https://aptible.slack.com/archives/C02NMLZ8N/p1526050573000420

cc @fancyremarker @UserNotFound @almathew 