### PR TITLE
Allow to pass options to pg_dump on db:dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Commands:
   aptible db:clone SOURCE DEST                                                                                                       # Clone a database to create a new one
   aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--size SIZE_GB]                             # Create a new database
   aptible db:deprovision HANDLE                                                                                                      # Deprovision a database
-  aptible db:dump HANDLE                                                                                                             # Dump a remote database to file
+  aptible db:dump HANDLE [pg_dump options]                                                                                           # Dump a remote database to file
   aptible db:execute HANDLE SQL_FILE                                                                                                 # Executes sql against a database
   aptible db:list                                                                                                                    # List all databases
   aptible db:reload HANDLE                                                                                                           # Reload a database

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -113,14 +113,15 @@ module Aptible
               render_database(database, database.account)
             end
 
-            desc 'db:dump HANDLE', 'Dump a remote database to file'
+            desc 'db:dump HANDLE [pg_dump options]',
+                 'Dump a remote database to file'
             option :environment
-            define_method 'db:dump' do |handle|
+            define_method 'db:dump' do |handle, *dump_options|
               database = ensure_database(options.merge(db: handle))
               with_postgres_tunnel(database) do |url|
                 filename = "#{handle}.dump"
                 CLI.logger.info "Dumping to #{filename}"
-                `pg_dump #{url} > #{filename}`
+                `pg_dump #{url} #{dump_options.shelljoin} > #{filename}`
               end
             end
 


### PR DESCRIPTION
We want to use the dump command like this:
`aptible db:dump HANDLE --exclude-table-data=events --exclude-table-data=versions`
to not dump data we don't need for our dev env. Not sure if I should have opened an issue first, if I was supposed to sorry!