### PR TITLE
db:dump and db:execute return non-zero exit codes when postgres command fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Commands:
   aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--size SIZE_GB]                             # Create a new database
   aptible db:deprovision HANDLE                                                                                                      # Deprovision a database
   aptible db:dump HANDLE [pg_dump options]                                                                                           # Dump a remote database to file
-  aptible db:execute HANDLE SQL_FILE                                                                                                 # Executes sql against a database
+  aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                               # Executes sql against a database
   aptible db:list                                                                                                                    # List all databases
   aptible db:reload HANDLE                                                                                                           # Reload a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                                              # Restart a database


### PR DESCRIPTION
https://aptible.zendesk.com/agent/tickets/19602

Also adds `--on-error-stop` flag to `db:execute` to make `psql` stop on error and return a non-zero exit code.