### PR TITLE
Support replication creation via the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Commands:
   aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                               # Executes sql against a database
   aptible db:list                                                                                                                    # List all databases
   aptible db:reload HANDLE                                                                                                           # Reload a database
+  aptible db:replicate SOURCE DEST                                                                                                   # Create a replica/follower of a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                                              # Restart a database
   aptible db:tunnel HANDLE                                                                                                           # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                              # Display a database URL

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Commands:
   aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                               # Executes sql against a database
   aptible db:list                                                                                                                    # List all databases
   aptible db:reload HANDLE                                                                                                           # Reload a database
-  aptible db:replicate SOURCE DEST                                                                                                   # Create a replica/follower of a database
+  aptible db:replicate HANDLE REPLICA_HANDLE                                                                                         # Create a replica/follower of a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                                              # Restart a database
   aptible db:tunnel HANDLE                                                                                                           # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                              # Display a database URL

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Commands:
   aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                               # Executes sql against a database
   aptible db:list                                                                                                                    # List all databases
   aptible db:reload HANDLE                                                                                                           # Reload a database
-  aptible db:replicate HANDLE REPLICA_HANDLE                                                                                         # Create a replica/follower of a database
+  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                             # Create a replica/follower of a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                                              # Restart a database
   aptible db:tunnel HANDLE                                                                                                           # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                              # Display a database URL

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -47,6 +47,15 @@ module Aptible
           databases_from_handle(dest_handle, source.account).first
         end
 
+        def replicate_database(source, dest_handle)
+          op = source.create_operation!(type: 'replicate', handle: dest_handle)
+          attach_to_operation_logs(op)
+
+          replica = databases_from_handle(dest_handle, source.account).first
+          attach_to_operation_logs(replica.operations.last)
+          replica
+        end
+
         # Creates a local tunnel and yields the helper
 
         def with_local_tunnel(credential, port = 0)

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -47,8 +47,14 @@ module Aptible
           databases_from_handle(dest_handle, source.account).first
         end
 
-        def replicate_database(source, dest_handle)
-          op = source.create_operation!(type: 'replicate', handle: dest_handle)
+        def replicate_database(source, dest_handle, options)
+          replication_params = {
+            type: 'replicate',
+            handle: dest_handle,
+            container_size: options[:container_size],
+            disk_size: options[:size]
+          }.reject { |_, v| v.nil? }
+          op = source.create_operation!(replication_params)
           attach_to_operation_logs(op)
 
           replica = databases_from_handle(dest_handle, source.account).first

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -114,21 +114,16 @@ module Aptible
               render_database(database, database.account)
             end
 
-            desc 'db:replicate HANDLE REPLICA_HANDLE',
+            desc 'db:replicate HANDLE REPLICA_HANDLE ' \
+                 '[--container-size SIZE_MB] [--size SIZE_GB]',
                  'Create a replica/follower of a database'
             option :environment
+            option :container_size, type: :numeric
+            option :size, type: :numeric
             define_method 'db:replicate' do |source_handle, dest_handle|
-              allowed_types = %w(postgresql redis mysql mongodb).freeze
-
               source = ensure_database(options.merge(db: source_handle))
-
-              unless allowed_types.include? source.type
-                raise Thor::Error, "Database type #{source.type} " \
-                  'is not supported for replication'
-              end
-
               CLI.logger.info "Replicating #{source_handle}..."
-              database = replicate_database(source, dest_handle)
+              database = replicate_database(source, dest_handle, options)
               render_database(database.reload, database.account)
             end
 

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -118,7 +118,15 @@ module Aptible
                  'Create a replica/follower of a database'
             option :environment
             define_method 'db:replicate' do |source_handle, dest_handle|
+              allowed_types = %w(postgresql redis mysql mongodb).freeze
+
               source = ensure_database(options.merge(db: source_handle))
+
+              unless allowed_types.include? source.type
+                raise Thor::Error, "Database type #{source.type} " \
+                  'is not supported for replication'
+              end
+
               CLI.logger.info "Replicating #{source_handle}..."
               database = replicate_database(source, dest_handle)
               render_database(database.reload, database.account)

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -114,6 +114,16 @@ module Aptible
               render_database(database, database.account)
             end
 
+            desc 'db:replicate SOURCE DEST',
+                 'Create a replica/follower of a database'
+            option :environment
+            define_method 'db:replicate' do |source_handle, dest_handle|
+              source = ensure_database(options.merge(db: source_handle))
+              CLI.logger.info "Replicating #{source_handle}..."
+              database = replicate_database(source, dest_handle)
+              render_database(database.reload, database.account)
+            end
+
             desc 'db:dump HANDLE [pg_dump options]',
                  'Dump a remote database to file'
             option :environment

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -114,7 +114,7 @@ module Aptible
               render_database(database, database.account)
             end
 
-            desc 'db:replicate SOURCE DEST',
+            desc 'db:replicate HANDLE REPLICA_HANDLE',
                  'Create a replica/follower of a database'
             option :environment
             define_method 'db:replicate' do |source_handle, dest_handle|

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -441,10 +441,11 @@ describe Aptible::CLI::Agent do
 
   describe '#db:replicate' do
     let(:master) { Fabricate(:database, handle: 'master') }
+    let(:influxdb) { Fabricate(:database, handle: 'inf', type: 'influxdb') }
     let(:replica) do
       Fabricate(:database, account: master.account, handle: 'replica')
     end
-    let(:databases) { [master] }
+    let(:databases) { [master, influxdb] }
 
     before { allow(Aptible::Api::Database).to receive(:all) { databases } }
 
@@ -475,6 +476,11 @@ describe Aptible::CLI::Agent do
     it 'fails if the DB is not found' do
       expect { subject.send('db:replicate', 'nope', 'replica') }
         .to raise_error(Thor::Error, 'Could not find database nope')
+    end
+
+    it 'fails if the DB is not a supported type' do
+      expect { subject.send('db:replicate', 'influxdb', 'replica') }
+        .to raise_error(Thor::Error)
     end
   end
 

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -440,26 +440,29 @@ describe Aptible::CLI::Agent do
   end
 
   describe '#db:replicate' do
-    let(:master) { Fabricate(:database, handle: 'master') }
-    let(:influxdb) { Fabricate(:database, handle: 'inf', type: 'influxdb') }
-    let(:replica) do
-      Fabricate(:database, account: master.account, handle: 'replica')
-    end
-    let(:databases) { [master, influxdb] }
-
+    let(:databases) { [] }
     before { allow(Aptible::Api::Database).to receive(:all) { databases } }
 
-    let(:op) { Fabricate(:operation) }
-    let(:provision) { Fabricate(:operation) }
+    def expect_replicate_database(opts = {})
+      master = Fabricate(:database, handle: 'master')
+      databases << master
+      replica = Fabricate(:database,
+                          account: master.account,
+                          handle: 'replica')
 
-    it 'allows replicating an existing database' do
+      op = Fabricate(:operation)
+
+      params = { type: 'replicate', handle: 'replica' }.merge(opts)
+      params[:disk_size] = params.delete(:size) if params[:size]
       expect(master).to receive(:create_operation!)
-        .with(type: 'replicate', handle: 'replica').and_return(op)
+        .with(**params).and_return(op)
 
       expect(subject).to receive(:attach_to_operation_logs).with(op) do
         databases << replica
         replica
       end
+
+      provision = Fabricate(:operation)
 
       expect(replica).to receive_message_chain(:operations, :last)
         .and_return(provision)
@@ -468,19 +471,27 @@ describe Aptible::CLI::Agent do
 
       expect(replica).to receive(:reload).and_return(replica)
 
+      subject.options = opts
       subject.send('db:replicate', 'master', 'replica')
 
       expect(captured_logs).to match(/replicating master/i)
     end
 
+    it 'allows replicating an existing database' do
+      expect_replicate_database
+    end
+
+    it 'allows replicating a database with a container size' do
+      expect_replicate_database(container_size: 40)
+    end
+
+    it 'allows replicating a database with a disk size' do
+      expect_replicate_database(size: 40)
+    end
+
     it 'fails if the DB is not found' do
       expect { subject.send('db:replicate', 'nope', 'replica') }
         .to raise_error(Thor::Error, 'Could not find database nope')
-    end
-
-    it 'fails if the DB is not a supported type' do
-      expect { subject.send('db:replicate', 'influxdb', 'replica') }
-        .to raise_error(Thor::Error)
     end
   end
 


### PR DESCRIPTION
Closes: https://aptible.atlassian.net/browse/DP-88

Allows for self-service DB replication from the command line:

![replicate](https://user-images.githubusercontent.com/6646098/66688844-07901c80-ec4e-11e9-9086-4737f754868b.gif)

It will output the operation logs of both the replication step (which is just two unhelpful lines) and the actual provisioning of the DB (which is what you really want to see).

If you try to replicate an unsupported DB type, it will prevent the queueing of the operation:

<img width="346" alt="Screen Shot 2019-10-11 at 5 34 26 PM" src="https://user-images.githubusercontent.com/6646098/66688881-3908e800-ec4e-11e9-9564-d2fb2636c66e.png">

Without that, it attempts to create the DB for the unsupported type, which ultimately fails to provision correctly. This seemed a cleaner way to handle that, but I'm open to thoughts on that bit.

This is draft as we'll need some documentation updates before this can ship /cc @UserNotFound @joshraker 
 
There's already an [integration spec](https://github.com/aptible/aptible-integration/blob/master/spec/database/initialize_from_spec.rb) that covers the underlying operation so I opted *not* to add anything to `aptible-integration` to cover this. It's just a slight wrapper with very little logic so the unit test should be fine. I spoke briefly with Frank on that, so I think it's consensus. Open to further testing thoughts if folks have them.