### PR TITLE
Prefer "--disk-size" over "--size"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,52 +29,52 @@ From `aptible help`:
 <!-- BEGIN USAGE -->
 ```
 Commands:
-  aptible apps                                                                                                                       # List all applications
-  aptible apps:create HANDLE                                                                                                         # Create a new application
-  aptible apps:deprovision                                                                                                           # Deprovision an app
-  aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                    # Scale a service
-  aptible backup:list DB_HANDLE                                                                                                      # List backups for a database
-  aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--size SIZE_GB]  # Restore a backup
-  aptible config                                                                                                                     # Print an app's current configuration
-  aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                   # Add an ENV variable to an app
-  aptible config:rm [VAR1] [VAR2] [...]                                                                                              # Remove an ENV variable from an app
-  aptible config:set [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                   # Add an ENV variable to an app
-  aptible config:unset [VAR1] [VAR2] [...]                                                                                           # Remove an ENV variable from an app
-  aptible db:backup HANDLE                                                                                                           # Backup a database
-  aptible db:clone SOURCE DEST                                                                                                       # Clone a database to create a new one
-  aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--size SIZE_GB]                             # Create a new database
-  aptible db:deprovision HANDLE                                                                                                      # Deprovision a database
-  aptible db:dump HANDLE [pg_dump options]                                                                                           # Dump a remote database to file
-  aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                               # Executes sql against a database
-  aptible db:list                                                                                                                    # List all databases
-  aptible db:reload HANDLE                                                                                                           # Reload a database
-  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                             # Create a replica/follower of a database
-  aptible db:restart HANDLE [--container-size SIZE_MB] [--size SIZE_GB]                                                              # Restart a database
-  aptible db:tunnel HANDLE                                                                                                           # Create a local tunnel to a database
-  aptible db:url HANDLE                                                                                                              # Display a database URL
-  aptible db:versions                                                                                                                # List available database versions
-  aptible deploy [OPTIONS] [VAR1=VAL1] [VAR2=VAL2] [...]                                                                             # Deploy an app
-  aptible domains                                                                                                                    # Print an app's current virtual domains - DEPRECATED
-  aptible endpoints:database:create DATABASE                                                                                         # Create a Database Endpoint
-  aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                  # Deprovision an App or Database Endpoint
-  aptible endpoints:https:create [--app APP] SERVICE                                                                                 # Create an App HTTPS Endpoint
-  aptible endpoints:https:modify [--app APP] ENDPOINT_HOSTNAME                                                                       # Modify an App HTTPS Endpoint
-  aptible endpoints:list [--app APP | --database DATABASE]                                                                           # List Endpoints for an App or Database
-  aptible endpoints:renew [--app APP] ENDPOINT_HOSTNAME                                                                              # Renew an App Managed TLS Endpoint
-  aptible endpoints:tcp:create [--app APP] SERVICE                                                                                   # Create an App TCP Endpoint
-  aptible endpoints:tcp:modify [--app APP] ENDPOINT_HOSTNAME                                                                         # Modify an App TCP Endpoint
-  aptible endpoints:tls:create [--app APP] SERVICE                                                                                   # Create an App TLS Endpoint
-  aptible endpoints:tls:modify [--app APP] ENDPOINT_HOSTNAME                                                                         # Modify an App TLS Endpoint
-  aptible help [COMMAND]                                                                                                             # Describe available commands or one specific command
-  aptible login                                                                                                                      # Log in to Aptible
-  aptible logs [--app APP | --database DATABASE]                                                                                     # Follows logs from a running app or database
-  aptible operation:cancel OPERATION_ID                                                                                              # Cancel a running operation
-  aptible ps                                                                                                                         # Display running processes for an app - DEPRECATED
-  aptible rebuild                                                                                                                    # Rebuild an app, and restart its services
-  aptible restart                                                                                                                    # Restart all services associated with an app
-  aptible services                                                                                                                   # List Services for an App
-  aptible ssh [COMMAND]                                                                                                              # Run a command against an app
-  aptible version                                                                                                                    # Print Aptible CLI version
+  aptible apps                                                                                                                            # List all applications
+  aptible apps:create HANDLE                                                                                                              # Create a new application
+  aptible apps:deprovision                                                                                                                # Deprovision an app
+  aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                         # Scale a service
+  aptible backup:list DB_HANDLE                                                                                                           # List backups for a database
+  aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--disk-size SIZE_GB]  # Restore a backup
+  aptible config                                                                                                                          # Print an app's current configuration
+  aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                        # Add an ENV variable to an app
+  aptible config:rm [VAR1] [VAR2] [...]                                                                                                   # Remove an ENV variable from an app
+  aptible config:set [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                        # Add an ENV variable to an app
+  aptible config:unset [VAR1] [VAR2] [...]                                                                                                # Remove an ENV variable from an app
+  aptible db:backup HANDLE                                                                                                                # Backup a database
+  aptible db:clone SOURCE DEST                                                                                                            # Clone a database to create a new one
+  aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--disk-size SIZE_GB]                             # Create a new database
+  aptible db:deprovision HANDLE                                                                                                           # Deprovision a database
+  aptible db:dump HANDLE [pg_dump options]                                                                                                # Dump a remote database to file
+  aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                                    # Executes sql against a database
+  aptible db:list                                                                                                                         # List all databases
+  aptible db:reload HANDLE                                                                                                                # Reload a database
+  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                             # Create a replica/follower of a database
+  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                                              # Restart a database
+  aptible db:tunnel HANDLE                                                                                                                # Create a local tunnel to a database
+  aptible db:url HANDLE                                                                                                                   # Display a database URL
+  aptible db:versions                                                                                                                     # List available database versions
+  aptible deploy [OPTIONS] [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                  # Deploy an app
+  aptible domains                                                                                                                         # Print an app's current virtual domains - DEPRECATED
+  aptible endpoints:database:create DATABASE                                                                                              # Create a Database Endpoint
+  aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                       # Deprovision an App or Database Endpoint
+  aptible endpoints:https:create [--app APP] SERVICE                                                                                      # Create an App HTTPS Endpoint
+  aptible endpoints:https:modify [--app APP] ENDPOINT_HOSTNAME                                                                            # Modify an App HTTPS Endpoint
+  aptible endpoints:list [--app APP | --database DATABASE]                                                                                # List Endpoints for an App or Database
+  aptible endpoints:renew [--app APP] ENDPOINT_HOSTNAME                                                                                   # Renew an App Managed TLS Endpoint
+  aptible endpoints:tcp:create [--app APP] SERVICE                                                                                        # Create an App TCP Endpoint
+  aptible endpoints:tcp:modify [--app APP] ENDPOINT_HOSTNAME                                                                              # Modify an App TCP Endpoint
+  aptible endpoints:tls:create [--app APP] SERVICE                                                                                        # Create an App TLS Endpoint
+  aptible endpoints:tls:modify [--app APP] ENDPOINT_HOSTNAME                                                                              # Modify an App TLS Endpoint
+  aptible help [COMMAND]                                                                                                                  # Describe available commands or one specific command
+  aptible login                                                                                                                           # Log in to Aptible
+  aptible logs [--app APP | --database DATABASE]                                                                                          # Follows logs from a running app or database
+  aptible operation:cancel OPERATION_ID                                                                                                   # Cancel a running operation
+  aptible ps                                                                                                                              # Display running processes for an app - DEPRECATED
+  aptible rebuild                                                                                                                         # Rebuild an app, and restart its services
+  aptible restart                                                                                                                         # Restart all services associated with an app
+  aptible services                                                                                                                        # List Services for an App
+  aptible ssh [COMMAND]                                                                                                                   # Run a command against an app
+  aptible version                                                                                                                         # Print Aptible CLI version
 ```
 <!-- END USAGE -->
 

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -9,12 +9,13 @@ module Aptible
 
             desc 'backup:restore BACKUP_ID ' \
                  '[--environment ENVIRONMENT_HANDLE] [--handle HANDLE] ' \
-                 '[--container-size SIZE_MB] [--size SIZE_GB]',
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]',
                  'Restore a backup'
             option :handle, desc: 'a name to use for the new database'
             option :environment, desc: 'a different environment to restore to'
             option :container_size, type: :numeric
             option :size, type: :numeric
+            option :disk_size, type: :numeric
             define_method 'backup:restore' do |backup_id|
               backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
               raise Thor::Error, "Backup ##{backup_id} not found" if backup.nil?
@@ -35,7 +36,7 @@ module Aptible
                 type: 'restore',
                 handle: handle,
                 container_size: options[:container_size],
-                disk_size: options[:size],
+                disk_size: options[:disk_size] || options[:size],
                 destination_account: destination_account
               }.delete_if { |_, v| v.nil? }
 

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -40,6 +40,12 @@ module Aptible
                 destination_account: destination_account
               }.delete_if { |_, v| v.nil? }
 
+              CLI.logger.warn([
+                'You have used the "--size" option to specify a disk size.',
+                'This option which be deprecated in a future version.',
+                'Please use the "--disk-size" option, instead.'
+              ].join("\n")) if options[:size]
+
               operation = backup.create_operation!(opts)
               CLI.logger.info "Restoring backup into #{handle}"
               attach_to_operation_logs(operation)

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -70,6 +70,12 @@ module Aptible
                 initial_disk_size: options[:disk_size] || options[:size]
               }.delete_if { |_, v| v.nil? }
 
+              CLI.logger.warn([
+                'You have used the "--size" option to specify a disk size.',
+                'This option which be deprecated in a future version.',
+                'Please use the "--disk-size" option, instead.'
+              ].join("\n")) if options[:size]
+
               type = options[:type]
               version = options[:version]
 
@@ -131,6 +137,12 @@ module Aptible
                 container_size: options[:container_size],
                 size: options[:disk_size] || options[:size]
               }.delete_if { |_, v| v.nil? }
+
+              CLI.logger.warn([
+                'You have used the "--size" option to specify a disk size.',
+                'This option which be deprecated in a future version.',
+                'Please use the "--disk-size" option, instead.'
+              ].join("\n")) if options[:size]
 
               database = replicate_database(source, dest_handle, opts)
               render_database(database.reload, database.account)
@@ -257,6 +269,12 @@ module Aptible
                 container_size: options[:container_size],
                 disk_size: options[:disk_size] || options[:size]
               }.delete_if { |_, v| v.nil? }
+
+              CLI.logger.warn([
+                'You have used the "--size" option to specify a disk size.',
+                'This option which be deprecated in a future version.',
+                'Please use the "--disk-size" option, instead.'
+              ].join("\n")) if options[:size]
 
               CLI.logger.info "Restarting #{database.handle}..."
               op = database.create_operation!(opts)

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -53,12 +53,13 @@ module Aptible
 
             desc 'db:create HANDLE ' \
                  '[--type TYPE] [--version VERSION] ' \
-                 '[--container-size SIZE_MB] [--size SIZE_GB]',
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]',
                  'Create a new database'
             option :type, type: :string
             option :version, type: :string
             option :container_size, type: :numeric
-            option :size, default: 10, type: :numeric
+            option :size, type: :numeric
+            option :disk_size, default: 10, type: :numeric
             option :environment
             define_method 'db:create' do |handle|
               account = ensure_environment(options)
@@ -66,7 +67,7 @@ module Aptible
               db_opts = {
                 handle: handle,
                 initial_container_size: options[:container_size],
-                initial_disk_size: options[:size]
+                initial_disk_size: options[:disk_size] || options[:size]
               }.delete_if { |_, v| v.nil? }
 
               type = options[:type]
@@ -87,7 +88,7 @@ module Aptible
               op_opts = {
                 type: 'provision',
                 container_size: options[:container_size],
-                disk_size: options[:size]
+                disk_size: options[:disk_size] || options[:size]
               }.delete_if { |_, v| v.nil? }
               op = database.create_operation(op_opts)
 
@@ -115,15 +116,23 @@ module Aptible
             end
 
             desc 'db:replicate HANDLE REPLICA_HANDLE ' \
-                 '[--container-size SIZE_MB] [--size SIZE_GB]',
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]',
                  'Create a replica/follower of a database'
             option :environment
             option :container_size, type: :numeric
             option :size, type: :numeric
+            option :disk_size, type: :numeric
             define_method 'db:replicate' do |source_handle, dest_handle|
               source = ensure_database(options.merge(db: source_handle))
               CLI.logger.info "Replicating #{source_handle}..."
-              database = replicate_database(source, dest_handle, options)
+
+              opts = {
+                environment: options[:environment],
+                container_size: options[:container_size],
+                size: options[:disk_size] || options[:size]
+              }.delete_if { |_, v| v.nil? }
+
+              database = replicate_database(source, dest_handle, opts)
               render_database(database.reload, database.account)
             end
 
@@ -234,10 +243,11 @@ module Aptible
             end
 
             desc 'db:restart HANDLE ' \
-                 '[--container-size SIZE_MB] [--size SIZE_GB]',
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]',
                  'Restart a database'
             option :environment
             option :container_size, type: :numeric
+            option :disk_size, type: :numeric
             option :size, type: :numeric
             define_method 'db:restart' do |handle|
               database = ensure_database(options.merge(db: handle))
@@ -245,7 +255,7 @@ module Aptible
               opts = {
                 type: 'restart',
                 container_size: options[:container_size],
-                disk_size: options[:size]
+                disk_size: options[:disk_size] || options[:size]
               }.delete_if { |_, v| v.nil? }
 
               CLI.logger.info "Restarting #{database.handle}..."

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -55,13 +55,23 @@ describe Aptible::CLI::Agent do
       subject.send('db:create', 'foo')
     end
 
-    it 'creates a new DB with a disk size' do
+    it 'creates a new DB with a (implicitly) disk size' do
       expect_provision_database(
         { handle: 'foo', type: 'postgresql', initial_disk_size: 200 },
         { disk_size: 200 }
       )
 
       subject.options = { type: 'postgresql', size: 200 }
+      subject.send('db:create', 'foo')
+    end
+
+    it 'creates a new DB with a disk-size' do
+      expect_provision_database(
+        { handle: 'foo', type: 'postgresql', initial_disk_size: 200 },
+        { disk_size: 200 }
+      )
+
+      subject.options = { type: 'postgresql', disk_size: 200 }
       subject.send('db:create', 'foo')
     end
 
@@ -377,13 +387,25 @@ describe Aptible::CLI::Agent do
       expect(captured_logs).to match(/restarting foobar/i)
     end
 
-    it 'allows restarting a database with a disk size' do
+    it 'allows restarting a database with (implicitly disk) size' do
       expect(database).to receive(:create_operation!)
         .with(type: 'restart', disk_size: 40).and_return(op)
 
       expect(subject).to receive(:attach_to_operation_logs).with(op)
 
       subject.options = { size: 40 }
+      subject.send('db:restart', handle)
+
+      expect(captured_logs).to match(/restarting foobar/i)
+    end
+
+    it 'allows restarting a database with a disk-size' do
+      expect(database).to receive(:create_operation!)
+        .with(type: 'restart', disk_size: 40).and_return(op)
+
+      expect(subject).to receive(:attach_to_operation_logs).with(op)
+
+      subject.options = { disk_size: 40 }
       subject.send('db:restart', handle)
 
       expect(captured_logs).to match(/restarting foobar/i)
@@ -485,8 +507,12 @@ describe Aptible::CLI::Agent do
       expect_replicate_database(container_size: 40)
     end
 
-    it 'allows replicating a database with a disk size' do
+    it 'allows replicating a database with an (implicitly) disk size option' do
       expect_replicate_database(size: 40)
+    end
+
+    it 'allows replicating a database with a disk-size option' do
+      expect_replicate_database(disk_size: 40)
     end
 
     it 'fails if the DB is not found' do


### PR DESCRIPTION
The `--size` option can be ambiguous, so we should prefer a `--disk-size` option.  The `--size` option will remain for compatibility, but will not be documented.

This affects:

* db:create
* db:restart
* db:replicate
* backup:restore