### PR TITLE
Adds backup:purge subcommand to purge a single backup by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Commands:
   aptible apps:deprovision                                                                                                           # Deprovision an app
   aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                    # Scale a service
   aptible backup:list DB_HANDLE                                                                                                      # List backups for a database
+  aptible backup:purge BACKUP_ID                                                                                                     # Restore a backup
   aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--size SIZE_GB]  # Restore a backup
   aptible config                                                                                                                     # Print an app's current configuration
   aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                   # Add an ENV variable to an app

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -78,6 +78,16 @@ module Aptible
                 end
               end
             end
+
+            desc 'backup:purge BACKUP_ID', 'Restore a backup'
+            define_method 'backup:purge' do |backup_id|
+              backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
+              raise Thor::Error, "Backup ##{backup_id} not found" if backup.nil?
+
+              operation = backup.create_operation!(type: 'purge')
+              CLI.logger.info "Purging backup #{backup_id}"
+              attach_to_operation_logs(operation)
+            end
           end
         end
       end

--- a/lib/aptible/cli/subcommands/inspect.rb
+++ b/lib/aptible/cli/subcommands/inspect.rb
@@ -19,7 +19,7 @@ module Aptible
             raise "Invalid scheme: #{uri.scheme} (use https)"
           end
 
-          apis = [Aptible::Auth, Aptible::Api, Aptible::Billing]
+          apis = [Aptible::Auth, Aptible::Api]
 
           api = apis.find do |klass|
             uri.host == URI(klass.configuration.root_url).host


### PR DESCRIPTION
Part of https://aptible.atlassian.net/browse/DP-202

Adds the backup:purge subcommand to create a `purge` operation on a
specific Backup specified by its ID.

Should not released until https://github.com/aptible/deploy-api/pull/714 is deployed

Example run:
<img width="379" alt="Screen Shot 2020-04-08 at 3 15 49 PM" src="https://user-images.githubusercontent.com/6646098/78830433-8ec80e00-79ad-11ea-85df-1e6e6df6d45c.png">
