### PR TITLE
Fix purge description

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Commands:
   aptible apps:deprovision                                                                                                                # Deprovision an app
   aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                         # Scale a service
   aptible backup:list DB_HANDLE                                                                                                           # List backups for a database
-  aptible backup:purge BACKUP_ID                                                                                                          # Restore a backup
+  aptible backup:purge BACKUP_ID                                                                                                          # Permanently delete a backup
   aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--disk-size SIZE_GB]  # Restore a backup
   aptible config                                                                                                                          # Print an app's current configuration
   aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                        # Add an ENV variable to an app

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -86,7 +86,7 @@ module Aptible
               end
             end
 
-            desc 'backup:purge BACKUP_ID', 'Restore a backup'
+            desc 'backup:purge BACKUP_ID', 'Permanently delete a backup'
             define_method 'backup:purge' do |backup_id|
               backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
               raise Thor::Error, "Backup ##{backup_id} not found" if backup.nil?

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.16.4'.freeze
+    VERSION = '0.16.5'.freeze
   end
 end


### PR DESCRIPTION
Backup purge had an incorrect description. This corrects it.

Needs a version bump since we already published the gem to RubyGems even though we never officially released the CLI toolbelt.