### PR TITLE
Pin aptible-auth gem version

### DIFF
--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aptible-resource', '~> 1.1'
   spec.add_dependency 'aptible-api', '~> 1.0'
-  spec.add_dependency 'aptible-auth', '~> 1.0'
+  spec.add_dependency 'aptible-auth', '~> 1.1.0'
   spec.add_dependency 'aptible-billing', '~> 1.0'
   spec.add_dependency 'thor', '~> 0.20.0'
   spec.add_dependency 'git'

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.16.5'.freeze
+    VERSION = '0.16.6'.freeze
   end
 end


### PR DESCRIPTION
Per https://aptible.slack.com/archives/CJZ7UBMJP/p1589492369030000

Most recent aptible-auth gem `1.2.0` is breaking login via the CLI when installed as a gem. Toolbelt installs are not affected.

This pins the version of the gem until a fix can be released there.