### PR TITLE
add CLI flags for logical replication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rack', '~> 1.0'
 
 group :test do
   gem 'webmock'
-  gem 'codecov', require: false
+  gem 'codecov', '~> 0.1.0', require: false
 end
 
 # Specify your gem's dependencies in aptible-cli.gemspec

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Commands:
   aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                                    # Executes sql against a database
   aptible db:list                                                                                                                         # List all databases
   aptible db:reload HANDLE                                                                                                                # Reload a database
-  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                             # Create a replica/follower of a database
+  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical] [--version VERSION]             # Create a replica/follower of a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                                              # Restart a database
   aptible db:tunnel HANDLE                                                                                                                # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                                   # Display a database URL

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Commands:
   aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                                    # Executes sql against a database
   aptible db:list                                                                                                                         # List all databases
   aptible db:reload HANDLE                                                                                                                # Reload a database
-  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical] [--version VERSION]             # Create a replica/follower of a database
+  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical --version VERSION]               # Create a replica/follower of a database
   aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                                              # Restart a database
   aptible db:tunnel HANDLE                                                                                                                # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                                   # Display a database URL

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -55,10 +55,10 @@ module Aptible
           }.reject { |_, v| v.nil? }
 
           if options[:logical]
-            replication_params.merge(type: 'replicate-logical',
-                                     docker_ref: options[:database_image])
+            replication_params[:type] = 'replicate-logical'
+            replication_params[:docker_ref] = options[:database_image]
           else
-            replication_params.merge(type: 'replicate')
+            replication_params[:type] = 'replicate'
           end
 
           op = source.create_operation!(replication_params)

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -49,11 +49,18 @@ module Aptible
 
         def replicate_database(source, dest_handle, options)
           replication_params = {
-            type: 'replicate',
             handle: dest_handle,
             container_size: options[:container_size],
             disk_size: options[:size]
           }.reject { |_, v| v.nil? }
+
+          if options[:logical]
+            replication_params.merge(type: 'replicate-logical',
+                                     docker_ref: options[:database_image])
+          else
+            replication_params.merge(type: 'replicate')
+          end
+
           op = source.create_operation!(replication_params)
           attach_to_operation_logs(op)
 

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -56,7 +56,8 @@ module Aptible
 
           if options[:logical]
             replication_params[:type] = 'replicate_logical'
-            replication_params[:docker_ref] = options[:database_image].docker_repo
+            replication_params[:docker_ref] =
+              options[:database_image].docker_repo
           else
             replication_params[:type] = 'replicate'
           end

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -55,8 +55,8 @@ module Aptible
           }.reject { |_, v| v.nil? }
 
           if options[:logical]
-            replication_params[:type] = 'replicate-logical'
-            replication_params[:docker_ref] = options[:database_image]
+            replication_params[:type] = 'replicate_logical'
+            replication_params[:docker_ref] = options[:database_image].docker_repo
           else
             replication_params[:type] = 'replicate'
           end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -122,20 +122,37 @@ module Aptible
             end
 
             desc 'db:replicate HANDLE REPLICA_HANDLE ' \
-                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]',
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB] ' \
+                 '[--logical] [--version VERSION]',
                  'Create a replica/follower of a database'
             option :environment
             option :container_size, type: :numeric
             option :size, type: :numeric
             option :disk_size, type: :numeric
+            option :logical, type: :boolean
+            option :version, type: :string
             define_method 'db:replicate' do |source_handle, dest_handle|
               source = ensure_database(options.merge(db: source_handle))
+
+              if source.type != 'postgresql'
+                raise Thor::Error, 'This command only works for PostgreSQL'
+              end
+
+              if options[:logical] && options[:version].nil?
+                raise Thor::Error, '--version is required for logical ' \
+                                   'replication'
+              end
+
+              image = find_database_image(source.type, version)
+
               CLI.logger.info "Replicating #{source_handle}..."
 
               opts = {
                 environment: options[:environment],
                 container_size: options[:container_size],
-                size: options[:disk_size] || options[:size]
+                size: options[:disk_size] || options[:size],
+                logical: options[:logical],
+                database_image: image
               }.delete_if { |_, v| v.nil? }
 
               CLI.logger.warn([

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -140,7 +140,7 @@ module Aptible
                                      'PostgreSQL'
                 end
                 if options[:version]
-                  image = find_database_image(source.type, version)
+                  image = find_database_image(source.type, options[:version])
                 else
                   raise Thor::Error, '--version is required for logical ' \
                                      'replication'

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -123,7 +123,7 @@ module Aptible
 
             desc 'db:replicate HANDLE REPLICA_HANDLE ' \
                  '[--container-size SIZE_MB] [--disk-size SIZE_GB] ' \
-                 '[--logical] [--version VERSION]',
+                 '[--logical --version VERSION]',
                  'Create a replica/follower of a database'
             option :environment
             option :container_size, type: :numeric

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -138,12 +138,14 @@ module Aptible
                 raise Thor::Error, 'This command only works for PostgreSQL'
               end
 
-              if options[:logical] && options[:version].nil?
-                raise Thor::Error, '--version is required for logical ' \
-                                   'replication'
+              if options[:logical]
+                if options[:version]
+                  image = find_database_image(source.type, version)
+                else
+                  raise Thor::Error, '--version is required for logical ' \
+                                     'replication'
+                end
               end
-
-              image = find_database_image(source.type, version)
 
               CLI.logger.info "Replicating #{source_handle}..."
 
@@ -152,7 +154,7 @@ module Aptible
                 container_size: options[:container_size],
                 size: options[:disk_size] || options[:size],
                 logical: options[:logical],
-                database_image: image
+                database_image: image || nil
               }.delete_if { |_, v| v.nil? }
 
               CLI.logger.warn([

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -134,11 +134,11 @@ module Aptible
             define_method 'db:replicate' do |source_handle, dest_handle|
               source = ensure_database(options.merge(db: source_handle))
 
-              if source.type != 'postgresql'
-                raise Thor::Error, 'This command only works for PostgreSQL'
-              end
-
               if options[:logical]
+                if source.type != 'postgresql'
+                  raise Thor::Error, 'Logical replication only works for ' \
+                                     'PostgreSQL'
+                end
                 if options[:version]
                   image = find_database_image(source.type, version)
                 else

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -530,7 +530,7 @@ describe Aptible::CLI::Agent do
       dbimg = Fabricate(:database_image,
                         type: 'postgresql',
                         version: 10,
-                        docker_ref: 'aptible/postgresql:10')
+                        docker_repo: 'aptible/postgresql:10')
 
       expect(subject).to receive(:find_database_image).with('postgresql', 10)
         .and_return(dbimg)
@@ -538,7 +538,7 @@ describe Aptible::CLI::Agent do
       op = Fabricate(:operation)
 
       params = { type: 'replicate_logical', handle: 'replica',
-                 docker_ref: dbimg.docker_ref }
+                 docker_ref: dbimg.docker_repo }
       expect(master).to receive(:create_operation!)
         .with(**params).and_return(op)
 

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -527,15 +527,16 @@ describe Aptible::CLI::Agent do
                           account: master.account,
                           handle: 'replica')
 
-      dbimg = Fabricate(:database_image, type: 'postgresql', version: 10)
+      dbimg = Fabricate(:database_image, type: 'postgresql', version: 10,
+                        docker_ref: 'aptible/postgresql:10')
 
       expect(subject).to receive(:find_database_image).with('postgresql', 10)
         .and_return(dbimg)
 
       op = Fabricate(:operation)
 
-      params = { type: 'replicate-logical', handle: 'replica',
-                 docker_ref: dbimg }
+      params = { type: 'replicate_logical', handle: 'replica',
+                 docker_ref: dbimg.docker_ref }
       expect(master).to receive(:create_operation!)
         .with(**params).and_return(op)
 

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -527,7 +527,9 @@ describe Aptible::CLI::Agent do
                           account: master.account,
                           handle: 'replica')
 
-      dbimg = Fabricate(:database_image, type: 'postgresql', version: 10,
+      dbimg = Fabricate(:database_image,
+                        type: 'postgresql',
+                        version: 10,
                         docker_ref: 'aptible/postgresql:10')
 
       expect(subject).to receive(:find_database_image).with('postgresql', 10)


### PR DESCRIPTION
This will, with corresponding changes to the Deploy API and backend, allow for logical replication of postgres Databases through the Aptible CLI when upgrading versions.