### PR TITLE
CLI command to list backups of deprovisioned databases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rack', '~> 1.0'
 
 group :test do
   gem 'webmock'
-  gem 'codecov', require: false
+  gem 'codecov', '~> 0.1.0', require: false
 end
 
 # Specify your gem's dependencies in aptible-cli.gemspec

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Commands:
   aptible apps:deprovision                                                                                                                # Deprovision an app
   aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                         # Scale a service
   aptible backup:list DB_HANDLE                                                                                                           # List backups for a database
+  aptible backup:orphaned                                                                                                                 # List backups associated with deprovisioned databases
   aptible backup:purge BACKUP_ID                                                                                                          # Permanently delete a backup
   aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--disk-size SIZE_GB]  # Restore a backup
   aptible config                                                                                                                          # Print an app's current configuration

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Commands:
   aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                         # Scale a service
   aptible backup:list DB_HANDLE                                                                                                           # List backups for a database
   aptible backup:orphaned                                                                                                                 # List backups associated with deprovisioned databases
-  aptible backup:purge BACKUP_ID                                                                                                          # Permanently delete a backup
+  aptible backup:purge BACKUP_ID                                                                                                          # Permanently delete a backup and any copies of it
   aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--disk-size SIZE_GB]  # Restore a backup
   aptible config                                                                                                                          # Print an app's current configuration
   aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                        # Add an ENV variable to an app

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aptible-resource', '~> 1.1'
-  spec.add_dependency 'aptible-api', '~> 1.0'
+  spec.add_dependency 'aptible-api', '~> 1.2'
   spec.add_dependency 'aptible-auth', '~> 1.1.0'
   spec.add_dependency 'aptible-billing', '~> 1.0'
   spec.add_dependency 'thor', '~> 0.20.0'


### PR DESCRIPTION
Allows listing "orphaned" backups (i.e. backups of deprovisioned databases, where the backup itself hasn't been purged). Adds in database info, including `deleted_at`, in an attempt to provide maximum context.

Q: Using `deleted_at` is consistent with our API, but not the terminology we use in our docs. I know we're trying to get more consistent about this, but I _also_ know that I want things to match the API. Is there any concerns about this term not matching our docs? I'm happy to make a note about the difference in terminology when updating the docs, if that would be sufficient.

See convo here for context: https://aptible.atlassian.net/jira/software/projects/DP/boards/3?selectedIssue=DP-294

Requires: https://github.com/aptible/aptible-api-ruby/pull/102 (I'm waiting on the merge to officially update the gemspec)