### PR TITLE
Pull domain from stack, don't default to aptible.in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'rack', '~> 1.0'
 
 group :test do
   gem 'webmock'
-  gem 'codecov', '~> 0.1.0', require: false
 end
 
 # Specify your gem's dependencies in aptible-cli.gemspec

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/aptible-cli.png)](https://rubygems.org/gems/aptible-cli)
 [![Build Status](https://travis-ci.org/aptible/aptible-cli.png?branch=master)](https://travis-ci.org/aptible/aptible-cli)
 [![Dependency Status](https://gemnasium.com/aptible/aptible-cli.png)](https://gemnasium.com/aptible/aptible-cli)
-[![codecov](https://codecov.io/gh/aptible/aptible-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/aptible/aptible-cli)
 [![Roadmap](https://badge.waffle.io/aptible/aptible-cli.svg?label=ready&title=roadmap)](http://waffle.io/aptible/aptible-cli)
 
 Command-line interface for Aptible services.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,6 @@ environment:
     - RUBY_VERSION: 23
 
 install:
-  # The SSL_CERT_* environment variables are here since otherwise calls to
-  # codecov.io wtill not work. These variables do have to be set in order for
-  # the gem to make calls to the Aptible API, since otherwise Ruby will fail
-  # with a certificate verification error.
-  - set SSL_CERT_DIR=%PROGRAMFILES%\Git\mingw64\ssl\certs
-  - set SSL_CERT_FILE=%PROGRAMFILES%\Git\mingw64\ssl\cert.pem
   # Override PATHEXT so our ssh bat file has a higher precedence.
   - set PATHEXT=.BAT;.COM;.EXE;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
   - set PATH=C:\Ruby%RUBY_VERSION%-x64\bin;%PATH%

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -104,10 +104,11 @@ module Aptible
 
         def local_url(credential, local_port)
           remote_url = credential.connection_url
-          uri = URI.parse(remote_url)
 
+          uri = URI.parse(remote_url)
+          domain = credential.database.account.stack.internal_domain
           "#{uri.scheme}://#{uri.user}:#{uri.password}@" \
-          "localhost.aptible.in:#{local_port}#{uri.path}"
+          "localhost.#{domain}:#{local_port}#{uri.path}"
         end
 
         def find_credential(database, type = nil)

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -13,7 +13,9 @@ describe Aptible::CLI::Agent do
   end
 
   let(:handle) { 'foobar' }
-  let(:database) { Fabricate(:database, handle: handle) }
+  let(:stack) { Fabricate(:stack, internal_domain: 'aptible.in') }
+  let(:account) { Fabricate(:account, stack: stack) }
+  let(:database) { Fabricate(:database, handle: handle, account: account) }
   let(:socat_helper) { SocatHelperMock.new(port: 4242) }
 
   describe '#db:create' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,14 +3,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 Bundler.require :development
 
-require 'simplecov'
-SimpleCov.start
-
-if ENV['CI']
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
-
 # Load shared spec files
 Dir["#{File.dirname(__FILE__)}/shared/**/*.rb"].each do |file|
   require file


### PR DESCRIPTION
This can't go live until we deploy API, but API has been passing aptible-integration tests, so I suppose that's not really a blocker