### PR TITLE
Allow passing a new KMS CMK ARN when restoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,54 +28,54 @@ From `aptible help`:
 <!-- BEGIN USAGE -->
 ```
 Commands:
-  aptible apps                                                                                                                                   # List all applications
-  aptible apps:create HANDLE                                                                                                                     # Create a new application
-  aptible apps:deprovision                                                                                                                       # Deprovision an app
-  aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                                # Scale a service
-  aptible backup:list DB_HANDLE                                                                                                                  # List backups for a database
-  aptible backup:orphaned                                                                                                                        # List backups associated with deprovisioned databases
-  aptible backup:purge BACKUP_ID                                                                                                                 # Permanently delete a backup and any copies of it
-  aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--disk-size SIZE_GB]         # Restore a backup
-  aptible config                                                                                                                                 # Print an app's current configuration
-  aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                               # Add an ENV variable to an app
-  aptible config:rm [VAR1] [VAR2] [...]                                                                                                          # Remove an ENV variable from an app
-  aptible config:set [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                               # Add an ENV variable to an app
-  aptible config:unset [VAR1] [VAR2] [...]                                                                                                       # Remove an ENV variable from an app
-  aptible db:backup HANDLE                                                                                                                       # Backup a database
-  aptible db:clone SOURCE DEST                                                                                                                   # Clone a database to create a new one
-  aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--disk-size SIZE_GB] [--key-arn KEY_ARN]                # Create a new database
-  aptible db:deprovision HANDLE                                                                                                                  # Deprovision a database
-  aptible db:dump HANDLE [pg_dump options]                                                                                                       # Dump a remote database to file
-  aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                                           # Executes sql against a database
-  aptible db:list                                                                                                                                # List all databases
-  aptible db:reload HANDLE                                                                                                                       # Reload a database
-  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical --version VERSION] [--key-arn KEY_ARN]  # Create a replica/follower of a database
-  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                                                     # Restart a database
-  aptible db:tunnel HANDLE                                                                                                                       # Create a local tunnel to a database
-  aptible db:url HANDLE                                                                                                                          # Display a database URL
-  aptible db:versions                                                                                                                            # List available database versions
-  aptible deploy [OPTIONS] [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                         # Deploy an app
-  aptible domains                                                                                                                                # Print an app's current virtual domains - DEPRECATED
-  aptible endpoints:database:create DATABASE                                                                                                     # Create a Database Endpoint
-  aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                              # Deprovision an App or Database Endpoint
-  aptible endpoints:https:create [--app APP] SERVICE                                                                                             # Create an App HTTPS Endpoint
-  aptible endpoints:https:modify [--app APP] ENDPOINT_HOSTNAME                                                                                   # Modify an App HTTPS Endpoint
-  aptible endpoints:list [--app APP | --database DATABASE]                                                                                       # List Endpoints for an App or Database
-  aptible endpoints:renew [--app APP] ENDPOINT_HOSTNAME                                                                                          # Renew an App Managed TLS Endpoint
-  aptible endpoints:tcp:create [--app APP] SERVICE                                                                                               # Create an App TCP Endpoint
-  aptible endpoints:tcp:modify [--app APP] ENDPOINT_HOSTNAME                                                                                     # Modify an App TCP Endpoint
-  aptible endpoints:tls:create [--app APP] SERVICE                                                                                               # Create an App TLS Endpoint
-  aptible endpoints:tls:modify [--app APP] ENDPOINT_HOSTNAME                                                                                     # Modify an App TLS Endpoint
-  aptible help [COMMAND]                                                                                                                         # Describe available commands or one specific command
-  aptible login                                                                                                                                  # Log in to Aptible
-  aptible logs [--app APP | --database DATABASE]                                                                                                 # Follows logs from a running app or database
-  aptible operation:cancel OPERATION_ID                                                                                                          # Cancel a running operation
-  aptible ps                                                                                                                                     # Display running processes for an app - DEPRECATED
-  aptible rebuild                                                                                                                                # Rebuild an app, and restart its services
-  aptible restart                                                                                                                                # Restart all services associated with an app
-  aptible services                                                                                                                               # List Services for an App
-  aptible ssh [COMMAND]                                                                                                                          # Run a command against an app
-  aptible version                                                                                                                                # Print Aptible CLI version
+  aptible apps                                                                                                                                                # List all applications
+  aptible apps:create HANDLE                                                                                                                                  # Create a new application
+  aptible apps:deprovision                                                                                                                                    # Deprovision an app
+  aptible apps:scale SERVICE [--container-count COUNT] [--container-size SIZE_MB]                                                                             # Scale a service
+  aptible backup:list DB_HANDLE                                                                                                                               # List backups for a database
+  aptible backup:orphaned                                                                                                                                     # List backups associated with deprovisioned databases
+  aptible backup:purge BACKUP_ID                                                                                                                              # Permanently delete a backup and any copies of it
+  aptible backup:restore BACKUP_ID [--environment ENVIRONMENT_HANDLE] [--handle HANDLE] [--container-size SIZE_MB] [--disk-size SIZE_GB] [--key-arn KEY_ARN]  # Restore a backup
+  aptible config                                                                                                                                              # Print an app's current configuration
+  aptible config:add [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                                            # Add an ENV variable to an app
+  aptible config:rm [VAR1] [VAR2] [...]                                                                                                                       # Remove an ENV variable from an app
+  aptible config:set [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                                            # Add an ENV variable to an app
+  aptible config:unset [VAR1] [VAR2] [...]                                                                                                                    # Remove an ENV variable from an app
+  aptible db:backup HANDLE                                                                                                                                    # Backup a database
+  aptible db:clone SOURCE DEST                                                                                                                                # Clone a database to create a new one
+  aptible db:create HANDLE [--type TYPE] [--version VERSION] [--container-size SIZE_MB] [--disk-size SIZE_GB] [--key-arn KEY_ARN]                             # Create a new database
+  aptible db:deprovision HANDLE                                                                                                                               # Deprovision a database
+  aptible db:dump HANDLE [pg_dump options]                                                                                                                    # Dump a remote database to file
+  aptible db:execute HANDLE SQL_FILE [--on-error-stop]                                                                                                        # Executes sql against a database
+  aptible db:list                                                                                                                                             # List all databases
+  aptible db:reload HANDLE                                                                                                                                    # Reload a database
+  aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical --version VERSION] [--key-arn KEY_ARN]               # Create a replica/follower of a database
+  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB]                                                                                  # Restart a database
+  aptible db:tunnel HANDLE                                                                                                                                    # Create a local tunnel to a database
+  aptible db:url HANDLE                                                                                                                                       # Display a database URL
+  aptible db:versions                                                                                                                                         # List available database versions
+  aptible deploy [OPTIONS] [VAR1=VAL1] [VAR2=VAL2] [...]                                                                                                      # Deploy an app
+  aptible domains                                                                                                                                             # Print an app's current virtual domains - DEPRECATED
+  aptible endpoints:database:create DATABASE                                                                                                                  # Create a Database Endpoint
+  aptible endpoints:deprovision [--app APP | --database DATABASE] ENDPOINT_HOSTNAME                                                                           # Deprovision an App or Database Endpoint
+  aptible endpoints:https:create [--app APP] SERVICE                                                                                                          # Create an App HTTPS Endpoint
+  aptible endpoints:https:modify [--app APP] ENDPOINT_HOSTNAME                                                                                                # Modify an App HTTPS Endpoint
+  aptible endpoints:list [--app APP | --database DATABASE]                                                                                                    # List Endpoints for an App or Database
+  aptible endpoints:renew [--app APP] ENDPOINT_HOSTNAME                                                                                                       # Renew an App Managed TLS Endpoint
+  aptible endpoints:tcp:create [--app APP] SERVICE                                                                                                            # Create an App TCP Endpoint
+  aptible endpoints:tcp:modify [--app APP] ENDPOINT_HOSTNAME                                                                                                  # Modify an App TCP Endpoint
+  aptible endpoints:tls:create [--app APP] SERVICE                                                                                                            # Create an App TLS Endpoint
+  aptible endpoints:tls:modify [--app APP] ENDPOINT_HOSTNAME                                                                                                  # Modify an App TLS Endpoint
+  aptible help [COMMAND]                                                                                                                                      # Describe available commands or one specific command
+  aptible login                                                                                                                                               # Log in to Aptible
+  aptible logs [--app APP | --database DATABASE]                                                                                                              # Follows logs from a running app or database
+  aptible operation:cancel OPERATION_ID                                                                                                                       # Cancel a running operation
+  aptible ps                                                                                                                                                  # Display running processes for an app - DEPRECATED
+  aptible rebuild                                                                                                                                             # Rebuild an app, and restart its services
+  aptible restart                                                                                                                                             # Restart all services associated with an app
+  aptible services                                                                                                                                            # List Services for an App
+  aptible ssh [COMMAND]                                                                                                                                       # Run a command against an app
+  aptible version                                                                                                                                             # Print Aptible CLI version
 ```
 <!-- END USAGE -->
 

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -9,13 +9,15 @@ module Aptible
 
             desc 'backup:restore BACKUP_ID ' \
                  '[--environment ENVIRONMENT_HANDLE] [--handle HANDLE] ' \
-                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]',
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB] ' \
+                 '[--key-arn KEY_ARN]',
                  'Restore a backup'
             option :handle, desc: 'a name to use for the new database'
             option :environment, desc: 'a different environment to restore to'
             option :container_size, type: :numeric
             option :size, type: :numeric
             option :disk_size, type: :numeric
+            option :key_arn, type: :string
             define_method 'backup:restore' do |backup_id|
               backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
               raise Thor::Error, "Backup ##{backup_id} not found" if backup.nil?
@@ -38,7 +40,8 @@ module Aptible
                 handle: handle,
                 container_size: options[:container_size],
                 disk_size: options[:disk_size] || options[:size],
-                destination_account: destination_account
+                destination_account: destination_account,
+                key_arn: options[:key_arn]
               }.delete_if { |_, v| v.nil? }
 
               CLI.logger.warn([


### PR DESCRIPTION
EBS supports changing encryption keys when restoring from backup. This gives us two things:

* Custom encryption keys for existing databases (or databases created without them)
* Rotating custom encryption keys

Pairs with https://github.com/aptible/sweetness/pull/1187 (restore behavior is actually broken either way without those changes)