### PR TITLE
Fix token handling

### DIFF
--- a/bin/aptible
+++ b/bin/aptible
@@ -10,7 +10,7 @@ end
 begin
   Aptible::CLI::Agent.start
 rescue HyperResource::ClientError => e
-  m = if e.body['error'] == 'invalid_token'
+  m = if %w(invalid_token expired_token).include? e.body['error']
         'API authentication error: please run aptible login'
       else
         "An error occurred: #{e.body['message']}"

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -235,11 +235,7 @@ module Aptible
 
       def warn_sso_enforcement
         # If the user is also a member of
-        begin
-          token = fetch_token
-        rescue StandardError
-          return
-        end
+        token = fetch_token
         reauth = Aptible::Auth::ReauthenticateOrganization.all(token: token)
         return if reauth.empty?
 
@@ -247,6 +243,7 @@ module Aptible
                          'login method (SSO or Aptible credentials) to access',
                          'these organizations:',
                          reauth.map(&:name)].join(' '))
+      rescue StandardError
       end
 
       def version_string

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.16.8'.freeze
+    VERSION = '0.16.9'.freeze
   end
 end


### PR DESCRIPTION
See: https://aptible.slack.com/archives/CJZ7UBMJP/p1604446855018500

This fixes two issues:
1) Our executable was no longer catching the correct error to print the user friendly error message
2) Fetching the token was no longer throwing an error, which was happening during the API call

This fixes both errors:

![image](https://user-images.githubusercontent.com/6646098/98055265-ad3a9e80-1e02-11eb-80a0-3aa12f97ac24.png)
