### PR TITLE
Add disk and container attributes to database JSON output.

### DIFF
--- a/lib/aptible/cli/resource_formatter.rb
+++ b/lib/aptible/cli/resource_formatter.rb
@@ -82,6 +82,7 @@ module Aptible
           node.value('handle', database.handle)
 
           node.value('type', database.type)
+          node.value('version', database.database_image.version)
           node.value('status', database.status)
 
           node.value('connection_url', database.connection_url)
@@ -92,6 +93,11 @@ module Aptible
             end
           end
           attach_account(node, account)
+
+          node.value('disk_type', database.disk.ebs_volume_type)
+          node.value('disk_size', database.disk.size)
+          node.value('container_size', \
+                     database.service.container_memory_limit_mb)
         end
 
         def inject_credential(node, credential)

--- a/spec/fabricators/database_disk_fabricator.rb
+++ b/spec/fabricators/database_disk_fabricator.rb
@@ -1,0 +1,7 @@
+class StubDatabaseDisk < OpenStruct
+end
+
+Fabricator(:database_disk, from: :stub_database_disk) do
+  size 100
+  ebs_volume_type { 'gb2' }
+end

--- a/spec/fabricators/database_fabricator.rb
+++ b/spec/fabricators/database_fabricator.rb
@@ -16,6 +16,8 @@ Fabricator(:database, from: :stub_database) do
   status 'provisioned'
   connection_url 'postgresql://aptible:password@10.252.1.125:49158/db'
   account
+  database_image
+  disk { Fabricate(:database_disk) }
   service { nil }
 
   backups { [] }


### PR DESCRIPTION
Display the disk type and size, as well as container size, and database version when `APTIBLE_OUTPUT_FORMAT=json aptible db:list` is used.

```
[
  {
    "id": 1,
    "handle": "test",
    "type": "postgresql",
    "version": "13",
    "status": "provisioned",
    "connection_url": "postgresql://aptible:password@db-test-1.aptible.in:26187/db",
    "credentials": [
      {
        "type": "postgresql",
        "connection_url": "postgresql://aptible:password@db-test-1.aptible.in:26187/db",
        "default": true
      }
    ],
    "environment": {
      "id": 1,
      "handle": "test"
    },
    "disk_type": "gp3",
    "disk_size": 10,
    "container_size": 1024
  }
]
```