### PR TITLE
View live operation logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Commands:
   aptible login                                                                                                                                               # Log in to Aptible
   aptible logs [--app APP | --database DATABASE]                                                                                                              # Follows logs from a running app or database
   aptible operation:cancel OPERATION_ID                                                                                                                       # Cancel a running operation
+  aptible operation:log OPERATION_ID                                                                                                                          # Follow log of a running operation
   aptible rebuild                                                                                                                                             # Rebuild an app, and restart its services
   aptible restart                                                                                                                                             # Restart all services associated with an app
   aptible services                                                                                                                                            # List Services for an App

--- a/lib/aptible/cli/subcommands/operation.rb
+++ b/lib/aptible/cli/subcommands/operation.rb
@@ -16,6 +16,24 @@ module Aptible
               CLI.logger.info m
               o.update!(cancelled: true)
             end
+
+            desc 'operation:log OPERATION_ID',
+                 'Follow log of a running operation'
+            define_method 'operation:log' do |operation_id|
+              o = Aptible::Api::Operation.find(operation_id, token: fetch_token)
+              raise "Operation ##{operation_id} not found" if o.nil?
+
+              if %w(failed succeeded).include? o.status
+                raise Thor::Error, "This operation has already #{o.status}. " \
+                                  'Only currently running operations are '\
+                                  'supported by this command at this time.'
+              end
+
+              m = "Streaming logs for #{prettify_operation(o)}..."
+              CLI.logger.info m
+
+              attach_to_operation_logs(o)
+            end
           end
         end
       end

--- a/spec/aptible/cli/subcommands/operation_spec.rb
+++ b/spec/aptible/cli/subcommands/operation_spec.rb
@@ -26,4 +26,50 @@ describe Aptible::CLI::Agent do
       subject.send('operation:cancel', 1)
     end
   end
+
+  describe '#operation:log' do
+    it 'fails if the operation cannot be found' do
+      expect(Aptible::Api::Operation).to receive(:find).with(1, token: token)
+        .and_return(nil)
+
+      expect { subject.send('operation:log', 1) }
+        .to raise_error('Operation #1 not found')
+    end
+
+    it 'connects to a running operation' do
+      op = Fabricate(:operation, status: 'running', type: 'restart')
+      expect(Aptible::Api::Operation).to receive(:find)
+        .with(op.id.to_s, token: token).and_return(op)
+
+      expect(subject).to receive(:attach_to_operation_logs).with(op)
+      subject.send('operation:log', op.id.to_s)
+    end
+
+    it 'connects to a queued operation' do
+      op = Fabricate(:operation, status: 'queued', type: 'restart')
+      expect(Aptible::Api::Operation).to receive(:find)
+        .with(op.id.to_s, token: token).and_return(op)
+
+      expect(subject).to receive(:attach_to_operation_logs).with(op)
+      subject.send('operation:log', op.id.to_s)
+    end
+
+    it 'does not connect to a failed operation' do
+      op = Fabricate(:operation, status: 'failed')
+      expect(Aptible::Api::Operation).to receive(:find)
+        .with(op.id.to_s, token: token).and_return(op)
+
+      expect { subject.send('operation:log', op.id.to_s) }
+        .to raise_error(Thor::Error, /Only currently running operations/)
+    end
+
+    it 'does not connect to a succeeded operation' do
+      op = Fabricate(:operation, status: 'succeeded')
+      expect(Aptible::Api::Operation).to receive(:find)
+        .with(op.id.to_s, token: token).and_return(op)
+
+      expect { subject.send('operation:log', op.id.to_s) }
+        .to raise_error(Thor::Error, /Only currently running operations/)
+    end
+  end
 end


### PR DESCRIPTION
Since we're not storing operation logs at this time, the best we can do is offer the ability to stream any logs for currently running operations, eg those that are in `queued` or `running` status.  Naturally, this will be more useful with a way to list operations for a resource, but that will take a fair bit more work to deliver.

I don't know the lifetime of the token used to connect to the bastion layer, so we may also want to additionally filter based on operation.created_at to avoid a stale token resulting in the error:

```
Streaming logs for running restart #26752786 on demo...
e36a58e0d23dfcf31cf945d6b704cb2a@bastion-layer-chaos-us-east-1.aptible.in: Permission denied (publickey).
Disconnected from logs, waiting for operation to complete
```