### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Commands:
   aptible db:modify HANDLE [--iops IOPS] [--volume-type [gp2, gp3]]                                                                                           # Modify a database disk
   aptible db:reload HANDLE                                                                                                                                    # Reload a database
   aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical --version VERSION] [--key-arn KEY_ARN]               # Create a replica/follower of a database
-  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB][--iops IOPS] [--volume-type [gp2, gp3]]                                          # Restart a database
+  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--iops IOPS] [--volume-type [gp2, gp3]]                                          # Restart a database
   aptible db:tunnel HANDLE                                                                                                                                    # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                                                       # Display a database URL
   aptible db:versions                                                                                                                                         # List available database versions

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Commands:
   aptible db:modify HANDLE [--iops IOPS] [--volume-type [gp2, gp3]]                                                                                           # Modify a database disk
   aptible db:reload HANDLE                                                                                                                                    # Reload a database
   aptible db:replicate HANDLE REPLICA_HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--logical --version VERSION] [--key-arn KEY_ARN]               # Create a replica/follower of a database
-  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--iops IOPS] [--volume-type [gp2, gp3]]                                          # Restart a database
+  aptible db:restart HANDLE [--container-size SIZE_MB] [--disk-size SIZE_GB] [--iops IOPS] [--volume-type [gp2, gp3]]                                         # Restart a database
   aptible db:tunnel HANDLE                                                                                                                                    # Create a local tunnel to a database
   aptible db:url HANDLE                                                                                                                                       # Display a database URL
   aptible db:versions                                                                                                                                         # List available database versions

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -279,7 +279,7 @@ module Aptible
             end
 
             desc 'db:restart HANDLE ' \
-                 '[--container-size SIZE_MB] [--disk-size SIZE_GB]' \
+                 '[--container-size SIZE_MB] [--disk-size SIZE_GB] ' \
                  '[--iops IOPS] [--volume-type [gp2, gp3]]',
                  'Restart a database'
             option :environment


### PR DESCRIPTION
Just adding a space in the `db:restart` options list.