### PR TITLE
Use the baseline_iops decorator to account for both GP2 and GP3 volume specs.

### DIFF
--- a/lib/aptible/cli/resource_formatter.rb
+++ b/lib/aptible/cli/resource_formatter.rb
@@ -103,7 +103,7 @@ module Aptible
             node.value('disk_modification_progress',
                        database.disk.modification_progress)
             node.value('disk_modification_status', database.disk.status)
-            node.value('disk_provisioned_iops', database.disk.provisioned_iops)
+            node.value('disk_provisioned_iops', database.disk.baseline_iops)
           end
 
           if database.service

--- a/spec/fabricators/database_disk_fabricator.rb
+++ b/spec/fabricators/database_disk_fabricator.rb
@@ -3,5 +3,6 @@ end
 
 Fabricator(:database_disk, from: :stub_database_disk) do
   size 100
-  ebs_volume_type { 'gb2' }
+  ebs_volume_type { 'gp2' }
+  baseline_iops '300'
 end


### PR DESCRIPTION
Non-critical, deploy any time after API update: https://github.com/aptible/deploy-api/pull/863

This will ensure we show the IOPS for both GP2 and GP3 volume types.