### PR TITLE
webauthn support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'pry', github: 'fancyremarker/pry', branch: 'aptible'
+gem 'pry',
+    git: 'https://github.com/fancyremarker/pry.git',
+    branch: 'aptible'
+
 gem 'activesupport', '~> 4.0'
 gem 'rack', '~> 1.0'
 

--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -25,9 +25,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aptible-auth', '~> 1.2.3'
   spec.add_dependency 'aptible-billing', '~> 1.0'
   spec.add_dependency 'thor', '~> 0.20.0'
-  spec.add_dependency 'git'
+  spec.add_dependency 'git', '< 1.10'
   spec.add_dependency 'term-ansicolor'
   spec.add_dependency 'chronic_duration', '~> 0.10.6'
+  spec.add_dependency 'cbor'
 
   # Temporarily pin ffi until https://github.com/ffi/ffi/issues/868 is fixed
   spec.add_dependency 'ffi', '<= 1.14.1' if Gem.win_platform?


### PR DESCRIPTION
The goal of this PR is to add support for WebAuthn in `aptible-cli`.  Previously we used the deprecated u2f-api to perform security key based authentication.  Since we migrated away from that in the browser, we also needed to add support in the cli.

## Notable changes

Notable changes compared to how it used to work:
- When a user has multiple credentials associated with it, we prompt the user to pick the credential they want to use
  - _This is a limitation with how the new [fido2-assert](https://developers.yubico.com/libfido2/Manuals/fido2-assert.html) cli works_

## Authentication flow with WebAuthn

- The user attempts to authenticate using their email and password
- `auth-api` returns an error response indicating the user needs to provide 2fa
- **if** we detect:
  - _the user has a valid security credential associated with their account_
    - **if** the user has multiple security credentials 
    - **then** we prompt the user to choose one
  - _has a security key attached to their computer;_
- **then** we prompt the user to touch their security key
- **else** we ask user to submit their OTP instead

## Technical overview of using `libfido2`

`libfido2-assert` is the cli command that we employ to generate an assertion from the security key.  This command requires (3) pieces of information:
- client data
- relying party
- credential id

The client data is a base64 blob that is a sha256 hash of a json string.  I've extracted the code to illustrate:

```ruby
client_data = {
  type: 'webauthn.get',
  challenge: challenge,
  origin: origin,
  crossOrigin: false
}.to_json

client_data_hash = Digest::SHA256.base64digest(client_data)
```

Because the cli command only accepts one credential id at a time, we cannot provide all the possible credentials the user has to a single device.  This is a limitation that requires us to prompt the user to pick the credential they want to try to use to generate an assertion from a security key.

After the user chooses the credential they want to use, we spawn a process for each security key that they have attached to their computer.  After they touch a device, `fido2-assert` attempts to generate an assertion from the device.  If it succeeds then we send that data to `auth-api`.  If it fails we display an error message and allow the user to touch a different security key.

## Installation requirements

We will try to package `libfido2` (which is a dependency for webauthn support) with homebrew but for other operating systems please see the installation guide for libfido2:

https://github.com/Yubico/libfido2

## Blocking PRs

- https://github.com/aptible/auth-api/pull/449
- https://github.com/aptible/auth-api/pull/451

## Note about potential issue

One potential issue that @UserNotFound discovered is:
- When using his nano security key
- and selecting the incorrect credential
- He sees an error message that he selected the wrong device (correct behavior)
- However, when the `ThottledAuthenticator` activates `fido2-assert` again it no longer asks for user presence (touching the key)
- And then causes the process to keep failure looping every 2 seconds

It's a weird edge-case that I hope is rare but something we might need to fix in the future.