### PR TITLE
correct the datadog metric drain url

### DIFF
--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -8,7 +8,7 @@ module Aptible
           'EU1' => 'https://app.datadoghq.eu',
           'US1-FED' => 'https://app.ddog-gov.com'
         }.freeze
-        PATH = '/api/v1/series'
+        PATH = '/api/v1/series'.freeze
 
         def self.included(thor)
           thor.class_eval do

--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -8,6 +8,7 @@ module Aptible
           'EU1' => 'https://app.datadoghq.eu',
           'US1-FED' => 'https://app.ddog-gov.com'
         }.freeze
+        PATH = '/api/v1/series'
 
         def self.included(thor)
           thor.class_eval do
@@ -106,7 +107,7 @@ module Aptible
                                      "Valid options are #{sites}"
                 end
 
-                config[:series_url] = site
+                config[:series_url] = site + PATH
               end
               opts = {
                 handle: handle,

--- a/spec/aptible/cli/subcommands/metric_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/metric_drain_spec.rb
@@ -145,7 +145,7 @@ describe Aptible::CLI::Agent do
           drain_type: :datadog,
           drain_configuration: {
             api_key: 'foobar',
-            series_url: 'https://app.datadoghq.eu'
+            series_url: 'https://app.datadoghq.eu/api/v1/series'
           }
         }
         expect_provision_metric_drain(opts)


### PR DESCRIPTION
Add missing `/api/v1/series` to DD metric drains.