### PR TITLE
Validate that the database type refers to an existing DatabaseImage.

### DIFF
--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -154,6 +154,19 @@ module Aptible
           raise Thor::Error, err
         end
 
+        def validate_image_type(type)
+          available_types = []
+
+          Aptible::Api::DatabaseImage.all(token: fetch_token).each do |i|
+            return true if i.type == type
+            available_types << i.type
+          end
+
+          err = "No Database Image of type \"#{type}\""
+          err = "#{err}, valid types: #{available_types.uniq.join(', ')}"
+          raise Thor::Error, err
+        end
+
         def render_database(database, account)
           Formatter.render(Renderer.current) do |root|
             root.keyed_object('connection_url') do |node|

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -84,6 +84,7 @@ module Aptible
               version = options[:version]
 
               if version && type
+                validate_image_type(type)
                 image = find_database_image(type, version)
                 db_opts[:type] = image.type
                 db_opts[:database_image] = image
@@ -91,6 +92,7 @@ module Aptible
                 raise Thor::Error, '--type is required when passing --version'
               else
                 db_opts[:type] = type || 'postgresql'
+                validate_image_type(db_opts[:type])
               end
 
               database = account.create_database!(db_opts)

--- a/spec/aptible/cli/helpers/database_spec.rb
+++ b/spec/aptible/cli/helpers/database_spec.rb
@@ -12,7 +12,10 @@ describe Aptible::CLI::Helpers::Database do
       Fabricate(:database_image, type: 'redis', version: '9.4')
     end
 
+    let(:token) { 'some-token' }
+
     before do
+      allow(subject).to receive(:fetch_token).and_return(token)
       allow(Aptible::Api::DatabaseImage).to receive(:all)
         .and_return([pg, redis])
     end

--- a/spec/aptible/cli/helpers/database_spec.rb
+++ b/spec/aptible/cli/helpers/database_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Aptible::CLI::Helpers::Database do
+  subject { Class.new.send(:include, described_class).new }
+
+  describe '#validate_image_type' do
+    let(:pg) do
+      Fabricate(:database_image, type: 'postgresql', version: '10')
+    end
+
+    let(:redis) do
+      Fabricate(:database_image, type: 'redis', version: '9.4')
+    end
+
+    before do
+      allow(Aptible::Api::DatabaseImage).to receive(:all)
+        .and_return([pg, redis])
+    end
+
+    it 'Raises an error if provided an invalid type' do
+      bad_type = 'cassandra'
+      err = "No Database Image of type \"#{bad_type}\", " \
+            "valid types: #{pg.type}, #{redis.type}"
+      expect do
+        subject.validate_image_type(bad_type)
+      end.to raise_error(Thor::Error, err)
+    end
+
+    it 'Retruns true when provided a valid type' do
+      expect(subject.validate_image_type(pg.type)).to be(true)
+    end
+  end
+end

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -22,6 +22,9 @@ describe Aptible::CLI::Agent do
     before do
       allow(Aptible::Api::Account).to receive(:all).and_return([account])
     end
+    before do
+      subject.stub(:validate_image_type) { true }
+    end
 
     def expect_provision_database(create_opts, provision_opts = {})
       db = Fabricate(:database)


### PR DESCRIPTION
Before:
```
$ aptible db:create foo --type cassandra
An error occurred: Validation failed: Database image can't be blank
```
After:
```
$ aptible db:create foo --type cassandra
No Database Image of type "cassandra", valid types: mongodb, mysql, redis, couchdb2, influxdb, elasticsearch, rabbitmq, postgresql, sftp, couchdb
```