### PR TITLE
Roll back to  older AWS SDK version

### DIFF
--- a/aptible-cli.gemspec
+++ b/aptible-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'term-ansicolor'
   spec.add_dependency 'chronic_duration', '~> 0.10.6'
   spec.add_dependency 'cbor'
-  spec.add_dependency 'aws-sdk-s3'
+  spec.add_dependency 'aws-sdk', '~> 2.0'
 
   # Temporarily pin ffi until https://github.com/ffi/ffi/issues/868 is fixed
   spec.add_dependency 'ffi', '<= 1.14.1' if Gem.win_platform?

--- a/lib/aptible/cli/helpers/s3_log_helpers.rb
+++ b/lib/aptible/cli/helpers/s3_log_helpers.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-s3'
+require 'aws-sdk'
 require 'pathname'
 
 module Aptible

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-s3'
+require 'aws-sdk'
 require 'shellwords'
 require 'time'
 

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.19.4'.freeze
+    VERSION = '0.19.5'.freeze
   end
 end


### PR DESCRIPTION
While we don't support using the aptible-cli gem directly, we, unfortunately, do exactly that in aptible-integration.  By rolling back here, we resolve the dependency issue breaking aptible-integration:

```
Bundler could not find compatible versions for gem "aws-sdk-core":
  In Gemfile:
    aptible-integration was resolved to 0.0.1, which depends on
      aptible-cli was resolved to 0.19.5, which depends on
        aws-sdk-core (~> 3.0)

    aptible-integration was resolved to 0.0.1, which depends on
      aws-sdk (~> 2.0) was resolved to 2.0.1.pre, which depends on
        aws-sdk-resources (= 2.0.1.pre) was resolved to 2.0.1.pre, which depends on
          aws-sdk-core (= 2.0.1)
```