### PR TITLE
Silence AWS sdk warning.

### DIFF
--- a/lib/aptible/cli/helpers/s3_log_helpers.rb
+++ b/lib/aptible/cli/helpers/s3_log_helpers.rb
@@ -215,7 +215,9 @@ module Aptible
         end
 
         def s3_client(region)
-          @s3_client ||= Aws::S3::Resource.new(region: region)
+          @s3_client ||= Kernel.silence_warnings do
+            Aws::S3::Resource.new(region: region)
+          end
         end
       end
     end


### PR DESCRIPTION
Silences the warning when the SDK is loaded when logs_from_archive is used

> Version 2 of the Ruby SDK will enter maintenance mode as of November 20, 2020. To continue receiving service updates and new features, please upgrade to Version 3. More information can be found here: https://aws.amazon.com/blogs/developer/deprecation-schedule-for-aws-sdk-for-ruby-v2/