### PR TITLE
Correct --git-commitish typo

### DIFF
--- a/lib/aptible/cli/subcommands/deploy.rb
+++ b/lib/aptible/cli/subcommands/deploy.rb
@@ -41,7 +41,7 @@ module Aptible
               git_ref = options[:git_commitish]
               if options[:git_detach]
                 if git_ref
-                  raise Thor::Error, 'The options --git-committish and ' \
+                  raise Thor::Error, 'The options --git-commitish and ' \
                                      '--git-detach are incompatible'
                 end
                 git_ref = NULL_SHA1


### PR DESCRIPTION
Updating the warning to be in line with the actual flag, which is `--git-commitish`

similar to https://github.com/aptible/primetime/pull/74