### PR TITLE
Update download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Command-line interface for Aptible services.
 
 **NOTE: To install the `aptible` tool as a system-level binary, Aptible
 recommends you install the
-[Aptible Toolbelt](https://support.aptible.com/toolbelt/)**, which is faster
-and more robust.
+[Aptible CLI](https://www.aptible.com/docs/cli)** directly, which is
+faster and more robust.
 
 Add the following line to your application's Gemfile.
 


### PR DESCRIPTION
The current link to https://support.aptible.com/toolbelt results in a 404 - it appears that https://www.aptible.com/docs/cli is the new location for the CLI download link.