### PR TITLE
Remove broken badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 
 # Aptible CLI
 
-[![Gem Version](https://badge.fury.io/rb/aptible-cli.png)](https://rubygems.org/gems/aptible-cli)
-[![Build Status](https://travis-ci.org/aptible/aptible-cli.png?branch=master)](https://travis-ci.org/aptible/aptible-cli)
-[![Dependency Status](https://gemnasium.com/aptible/aptible-cli.png)](https://gemnasium.com/aptible/aptible-cli)
-[![Roadmap](https://badge.waffle.io/aptible/aptible-cli.svg?label=ready&title=roadmap)](http://waffle.io/aptible/aptible-cli)
-
 Command-line interface for Aptible services.
 
 ## Installation


### PR DESCRIPTION
None of the badges in the README work for me:
<img width="408" alt="Screenshot 2023-05-01 at 5 53 24 pm" src="https://user-images.githubusercontent.com/712727/235425612-080d3db9-0627-4373-a50a-5683651a9e68.png">

- Unsure why the `fury.io` badge doesn't work
- The Travis badge returns a HTTP 301 redirect to their home page
- Gemnasium was acquired by GitLab
- Waffle.io shut down in 2019