### PR TITLE
include operations in JSON for automatic backups

### DIFF
--- a/lib/aptible/cli/resource_formatter.rb
+++ b/lib/aptible/cli/resource_formatter.rb
@@ -50,8 +50,7 @@ module Aptible
             end
           end
 
-          if bu_operation && \
-             backup.manual && !backup.copied_from
+          if bu_operation && !backup.copied_from
             node.keyed_object('created_from_operation', 'id') do |n|
               inject_operation(n, bu_operation)
             end


### PR DESCRIPTION
in order to allow a user to use the `aptible backup:list` command to filter out automatic backups which are not yet complete, include the operation information in the JSON output.