### PR TITLE
Quality of life requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aptible-cli (0.24.0)
+    aptible-cli (0.24.1)
       activesupport (>= 4.0, < 6.0)
       aptible-api (~> 1.6.5)
       aptible-auth (~> 1.2.5)

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -37,11 +37,17 @@ module Aptible
 
         def ensure_default_environment
           environments = Aptible::Api::Account.all(token: fetch_token)
-          return environments.first if environments.count == 1
-
-          raise Thor::Error, <<-ERR.gsub(/\s+/, ' ').strip
-            Multiple environments available, please specify with --environment
-          ERR
+          case environments.count
+          when 0
+            e = 'No environments. Go to https://app.aptible.com/ to proceed'
+            raise Thor::Error, e
+          when 1
+            return environments.first
+          else
+            raise Thor::Error, <<-ERR.gsub(/\s+/, ' ').strip
+              Multiple environments available, please specify with --environment or --env
+            ERR
+          end
         end
       end
     end

--- a/lib/aptible/cli/resource_formatter.rb
+++ b/lib/aptible/cli/resource_formatter.rb
@@ -157,6 +157,7 @@ module Aptible
           node.value('command', service.command || 'CMD')
           node.value('container_count', service.container_count)
           node.value('container_size', service.container_memory_limit_mb)
+          node.value('container_profile', service.instance_class.to_s[/[a-z]/])
 
           attach_app(node, app)
         end

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -9,7 +9,7 @@ module Aptible
             include Helpers::Token
 
             desc 'apps', 'List all applications'
-            option :environment
+            option :environment, aliases: '--env'
             def apps
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
@@ -28,7 +28,7 @@ module Aptible
             end
 
             desc 'apps:create HANDLE', 'Create a new application'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'apps:create' do |handle|
               environment = ensure_environment(options)
               app = environment.create_app(handle: handle)
@@ -104,7 +104,7 @@ module Aptible
                  ' ENVIRONMENT_HANDLE]', 'Rename an app handle. In order'\
                  ' for the new app handle to appear in log drain and metric'\
                  ' drain destinations, you must restart the app.'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'apps:rename' do |old_handle, new_handle|
               env = ensure_environment(options)
               app = ensure_app(options.merge(app: old_handle))

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -69,9 +69,11 @@ module Aptible
                 raise Thor::Error, m
               end
 
-              if container_count.nil? && container_size.nil?
-                raise Thor::Error,
-                      'Provide at least --container-count or --container-size'
+              if container_count.nil? && container_size.nil? &&
+                 container_profile.nil?
+                m = 'Provide at least --container-count, --container-size, ' \
+                    'or --container-profile'
+                raise Thor::Error m
               end
 
               # We don't validate any parameters here: API will do that for us.

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -73,7 +73,7 @@ module Aptible
                  container_profile.nil?
                 m = 'Provide at least --container-count, --container-size, ' \
                     'or --container-profile'
-                raise Thor::Error m
+                raise Thor::Error, m
               end
 
               # We don't validate any parameters here: API will do that for us.

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -71,7 +71,7 @@ module Aptible
             desc 'backup:list DB_HANDLE', 'List backups for a database'
             option :environment, aliases: '--env'
             option :max_age,
-                   default: '1mo',
+                   default: '99y',
                    desc: 'Limit backups returned (example usage: 1w, 1y, etc.)'
             define_method 'backup:list' do |handle|
               age = ChronicDuration.parse(options[:max_age])
@@ -97,7 +97,7 @@ module Aptible
             desc 'backup:orphaned', 'List backups associated with ' \
                                     'deprovisioned databases'
             option :environment, aliases: '--env'
-            option :max_age, default: '1y',
+            option :max_age, default: '99y',
                              desc: 'Limit backups returned '\
                                    '(example usage: 1w, 1y, etc.)'
             define_method 'backup:orphaned' do

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -14,7 +14,8 @@ module Aptible
                  '[--key-arn KEY_ARN]',
                  'Restore a backup'
             option :handle, desc: 'a name to use for the new database'
-            option :environment, desc: 'a different environment to restore to'
+            option :environment, aliases: '--env',
+                                 desc: 'a different environment to restore to'
             option :container_size, type: :numeric
             option :size, type: :numeric
             option :disk_size, type: :numeric
@@ -68,7 +69,7 @@ module Aptible
             end
 
             desc 'backup:list DB_HANDLE', 'List backups for a database'
-            option :environment
+            option :environment, aliases: '--env'
             option :max_age,
                    default: '1mo',
                    desc: 'Limit backups returned (example usage: 1w, 1y, etc.)'
@@ -95,7 +96,7 @@ module Aptible
 
             desc 'backup:orphaned', 'List backups associated with ' \
                                     'deprovisioned databases'
-            option :environment
+            option :environment, aliases: '--env'
             option :max_age, default: '1y',
                              desc: 'Limit backups returned '\
                                    '(example usage: 1w, 1y, etc.)'

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -1,5 +1,4 @@
 require 'shellwords'
-
 module Aptible
   module CLI
     module Subcommands
@@ -72,6 +71,7 @@ module Aptible
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
               env = Hash[args.map do |arg|
+                arg = arg.split('=')[0]
                 validate_env_key!(arg)
                 [arg, '']
               end]

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -14,7 +14,7 @@ module Aptible
             include Term::ANSIColor
 
             desc 'db:list', 'List all databases'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:list' do
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
@@ -63,7 +63,7 @@ module Aptible
             option :disk_size, default: 10, type: :numeric
             option :size, type: :numeric
             option :key_arn, type: :string
-            option :environment
+            option :environment, aliases: '--env'
             option :container_profile, type: :string,
                                        desc: 'Examples: m c r'
             option :iops, type: :numeric
@@ -126,7 +126,7 @@ module Aptible
             end
 
             desc 'db:clone SOURCE DEST', 'Clone a database to create a new one'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:clone' do |source_handle, dest_handle|
               # TODO: Deprecate + recommend backup
               source = ensure_database(options.merge(db: source_handle))
@@ -139,7 +139,7 @@ module Aptible
                  '[--container-profile PROFILE] [--iops IOPS] ' \
                  '[--logical --version VERSION] [--key-arn KEY_ARN]',
                  'Create a replica/follower of a database'
-            option :environment
+            option :environment, aliases: '--env'
             option :container_size, type: :numeric
             option :size, type: :numeric
             option :disk_size, type: :numeric
@@ -191,7 +191,7 @@ module Aptible
 
             desc 'db:dump HANDLE [pg_dump options]',
                  'Dump a remote database to file'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:dump' do |handle, *dump_options|
               database = ensure_database(options.merge(db: handle))
               with_postgres_tunnel(database) do |url|
@@ -204,7 +204,7 @@ module Aptible
 
             desc 'db:execute HANDLE SQL_FILE [--on-error-stop]',
                  'Executes sql against a database'
-            option :environment
+            option :environment, aliases: '--env'
             option :on_error_stop, type: :boolean
             define_method 'db:execute' do |handle, sql_path|
               database = ensure_database(options.merge(db: handle))
@@ -217,7 +217,7 @@ module Aptible
             end
 
             desc 'db:tunnel HANDLE', 'Create a local tunnel to a database'
-            option :environment
+            option :environment, aliases: '--env'
             option :port, type: :numeric
             option :type, type: :string
             define_method 'db:tunnel' do |handle|
@@ -262,7 +262,7 @@ module Aptible
             end
 
             desc 'db:deprovision HANDLE', 'Deprovision a database'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:deprovision' do |handle|
               database = ensure_database(options.merge(db: handle))
               CLI.logger.info "Deprovisioning #{database.handle}..."
@@ -278,7 +278,7 @@ module Aptible
             end
 
             desc 'db:backup HANDLE', 'Backup a database'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:backup' do |handle|
               database = ensure_database(options.merge(db: handle))
               CLI.logger.info "Backing up #{database.handle}..."
@@ -287,7 +287,7 @@ module Aptible
             end
 
             desc 'db:reload HANDLE', 'Reload a database'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:reload' do |handle|
               database = ensure_database(options.merge(db: handle))
               CLI.logger.info "Reloading #{database.handle}..."
@@ -300,7 +300,7 @@ module Aptible
                  '[--container-profile PROFILE] [--iops IOPS] ' \
                  '[--volume-type [gp2, gp3]]',
                  'Restart a database'
-            option :environment
+            option :environment, aliases: '--env'
             option :container_size, type: :numeric
             option :container_profile, type: :string,
                                        desc: 'Examples: m c r'
@@ -335,7 +335,7 @@ module Aptible
             desc 'db:modify HANDLE ' \
                  '[--iops IOPS] [--volume-type [gp2, gp3]]',
                  'Modify a database disk'
-            option :environment
+            option :environment, aliases: '--env'
             option :iops, type: :numeric
             option :volume_type
             define_method 'db:modify' do |handle|
@@ -354,7 +354,7 @@ module Aptible
             end
 
             desc 'db:url HANDLE', 'Display a database URL'
-            option :environment
+            option :environment, aliases: '--env'
             option :type, type: :string
             define_method 'db:url' do |handle|
               database = ensure_database(options.merge(db: handle))
@@ -371,7 +371,7 @@ module Aptible
                  ' ENVIRONMENT_HANDLE]', 'Rename a database handle. In order'\
                  ' for the new database handle to appear in log drain and'\
                  ' metric drain destinations, you must reload the database.'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'db:rename' do |old_handle, new_handle|
               env = ensure_environment(options)
               db = ensure_database(options.merge(db: old_handle))

--- a/lib/aptible/cli/subcommands/environment.rb
+++ b/lib/aptible/cli/subcommands/environment.rb
@@ -8,7 +8,7 @@ module Aptible
             include Helpers::Token
 
             desc 'environment:list', 'List all environments'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'environment:list' do
               Formatter.render(Renderer.current) do |root|
                 root.keyed_list(
@@ -25,7 +25,7 @@ module Aptible
 
             desc 'environment:ca_cert',
                  'Retrieve the CA certificate associated with the environment'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'environment:ca_cert' do
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(

--- a/lib/aptible/cli/subcommands/log_drain.rb
+++ b/lib/aptible/cli/subcommands/log_drain.rb
@@ -19,11 +19,11 @@ module Aptible
               option :drain_databases, default: true, type: :boolean
               option :drain_ephemeral_sessions, default: true, type: :boolean
               option :drain_proxies, default: true, type: :boolean
-              option :environment
+              option :environment, aliases: '--env'
             end
 
             desc 'log_drain:list', 'List all Log Drains'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'log_drain:list' do
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
@@ -137,7 +137,7 @@ module Aptible
 
             desc 'log_drain:deprovision HANDLE --environment ENVIRONMENT',
                  'Deprovisions a log drain'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'log_drain:deprovision' do |handle|
               account = ensure_environment(options)
               drain = ensure_log_drain(account, handle)

--- a/lib/aptible/cli/subcommands/maintenance.rb
+++ b/lib/aptible/cli/subcommands/maintenance.rb
@@ -11,7 +11,7 @@ module Aptible
             desc 'maintenance:apps',
                  'List Apps impacted by maintenance schedules where '\
                  'restarts are required'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'maintenance:apps' do
               found_maintenance = false
               m = maintenance_apps
@@ -46,7 +46,7 @@ module Aptible
             desc 'maintenance:dbs',
                  'List Databases impacted by maintenance schedules where '\
                  'restarts are required'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'maintenance:dbs' do
               found_maintenance = false
               m = maintenance_databases

--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -18,7 +18,7 @@ module Aptible
             include Helpers::MetricDrain
 
             desc 'metric_drain:list', 'List all Metric Drains'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'metric_drain:list' do
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
@@ -40,7 +40,7 @@ module Aptible
                  '--db DATABASE_HANDLE --environment ENVIRONMENT',
                  'Create an InfluxDB Metric Drain'
             option :db, type: :string
-            option :environment
+            option :environment, aliases: '--env'
 
             define_method 'metric_drain:create:influxdb' do |handle|
               account = ensure_environment(options)
@@ -66,7 +66,7 @@ module Aptible
             option :password, type: :string
             option :url, type: :string
             option :db, type: :string
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'metric_drain:create:influxdb:custom' do |handle|
               account = ensure_environment(options)
 
@@ -95,7 +95,7 @@ module Aptible
             option :org, type: :string
             option :token, type: :string
             option :url, type: :string
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'metric_drain:create:influxdb:customv2' do |handle|
               account = ensure_environment(options)
 
@@ -121,7 +121,7 @@ module Aptible
                  'Create a Datadog Metric Drain'
             option :api_key, type: :string
             option :site, type: :string
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'metric_drain:create:datadog' do |handle|
               account = ensure_environment(options)
 
@@ -150,7 +150,7 @@ module Aptible
 
             desc 'metric_drain:deprovision HANDLE --environment ENVIRONMENT',
                  'Deprovisions a Metric Drain'
-            option :environment
+            option :environment, aliases: '--env'
             define_method 'metric_drain:deprovision' do |handle|
               account = ensure_environment(options)
               drain = ensure_metric_drain(account, handle)

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.24.0'.freeze
+    VERSION = '0.24.1'.freeze
   end
 end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -93,11 +93,13 @@ describe Aptible::CLI::Agent do
 
       s1 = Fabricate(
         :service,
-        app: app, process_type: 's1', command: 'true', container_count: 2
+        app: app, process_type: 's1', command: 'true', container_count: 2,
+        instance_class: 'm5'
       )
       s2 = Fabricate(
         :service,
-        app: app, process_type: 's2', container_memory_limit_mb: 2048
+        app: app, process_type: 's2', container_memory_limit_mb: 2048,
+        instance_class: 'r5'
       )
 
       expected_json = [
@@ -118,6 +120,7 @@ describe Aptible::CLI::Agent do
               'id' => s1.id,
               'command' => s1.command,
               'container_count' => s1.container_count,
+              'container_profile' => 'm',
               'container_size' => s1.container_memory_limit_mb,
               'created_at' => fmt_time(s1.created_at)
             },
@@ -126,6 +129,7 @@ describe Aptible::CLI::Agent do
               'id' => s2.id,
               'command' => 'CMD',
               'container_count' => s2.container_count,
+              'container_profile' => 'r',
               'container_size' => s2.container_memory_limit_mb,
               'created_at' => fmt_time(s2.created_at)
             }

--- a/spec/aptible/cli/subcommands/config_spec.rb
+++ b/spec/aptible/cli/subcommands/config_spec.rb
@@ -109,6 +109,17 @@ describe Aptible::CLI::Agent do
       subject.send('config:unset', 'FOO')
     end
 
+    it 'unsets environment variables even if the user passes a value' do
+      expect(app).to receive(:create_operation!)
+        .with(type: 'configure', env: { 'FOO' => '' })
+        .and_return(operation)
+
+      expect(subject).to receive(:attach_to_operation_logs)
+        .with(operation)
+
+      subject.send('config:unset', 'FOO=whoops')
+    end
+
     it 'rejects environment variables that start with -' do
       expect { subject.send('config:rm', '-foo') }
         .to raise_error(/invalid argument/im)

--- a/spec/aptible/cli/subcommands/services_spec.rb
+++ b/spec/aptible/cli/subcommands/services_spec.rb
@@ -46,6 +46,14 @@ describe Aptible::CLI::Agent do
       expect(captured_output_text.split("\n")).to include('Container Count: 3')
     end
 
+    it 'lists container profile' do
+      Fabricate(:service, app: app, instance_class: 'u7')
+      subject.send('services')
+
+      expect(captured_output_text.split("\n"))
+        .to include('Container Profile: u')
+    end
+
     it 'lists multiple services' do
       Fabricate(:service, app: app, process_type: 'foo')
       Fabricate(:service, app: app, process_type: 'bar')


### PR DESCRIPTION
Fix misleading error when no environments are available (it used to say there were multiple...) which would occur when a user had no permissions, or before they had completed FTUX.

Support alias `--env` for `--environment` on all commands.

```
[aptible-cli]$ aptible db:list --env chaos
=== chaos
foo
bar
```

Allow an app:scale operation to specify _just_ the container profile option.

Return the container profile in `aptible services` output.

List all backups by default.