### PR TITLE
feat: telemetry for all commands

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -8,6 +8,7 @@ require 'chronic_duration'
 
 require_relative 'helpers/ssh'
 require_relative 'helpers/token'
+require_relative 'helpers/telemetry'
 require_relative 'helpers/operation'
 require_relative 'helpers/environment'
 require_relative 'helpers/app'

--- a/lib/aptible/cli/helpers/telemetry.rb
+++ b/lib/aptible/cli/helpers/telemetry.rb
@@ -1,0 +1,44 @@
+require 'httpclient'
+require 'securerandom'
+require 'uri'
+
+module Aptible
+  module CLI
+    module Helpers
+      module Telemetry
+        def telemetry(cmd, options = {})
+          token_hash = decode_token
+          format = Renderer.format
+          sub = token_hash[0]['sub']
+          parsed_url = URI.parse(sub)
+          path_components = parsed_url.path.split('/')
+          user_or_org_id = path_components.last
+          client = HTTPClient.new
+
+          value = {
+            'email' => token_hash[0]['email'],
+            'format' => format,
+            'cmd' => cmd,
+            'options' => options
+          }
+          response = nil
+
+          begin
+            uri = URI("https://tuna.aptible.com/www/e")
+            response = client.get(uri, {
+              'id' => SecureRandom.uuid,
+              'user_id' => user_or_org_id,
+              'type' => 'cli_telemetry',
+              'url' => sub,
+              'value' => value
+            })
+          rescue => e
+            # since this is just for telemetry we don't want to notify
+            # user of an error
+            # puts "Error: #{e.message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aptible/cli/helpers/token.rb
+++ b/lib/aptible/cli/helpers/token.rb
@@ -1,4 +1,5 @@
 require 'aptible/auth'
+require 'jwt'
 
 require_relative 'config_path'
 
@@ -45,6 +46,11 @@ module Aptible
 
         def token_file
           File.join(aptible_config_path, 'tokens.json').freeze
+        end
+
+        def decode_token
+          tok = fetch_token
+          JWT.decode(tok, nil, false)
         end
       end
     end

--- a/lib/aptible/cli/renderer.rb
+++ b/lib/aptible/cli/renderer.rb
@@ -9,8 +9,12 @@ module Aptible
     module Renderer
       FORMAT_VAR = 'APTIBLE_OUTPUT_FORMAT'.freeze
 
+      def self.format
+        ENV[FORMAT_VAR]
+      end
+
       def self.current
-        case (format = ENV[FORMAT_VAR])
+        case self.format 
         when 'json'
           Json.new
         when 'text'

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -7,10 +7,13 @@ module Aptible
             include Helpers::App
             include Helpers::Environment
             include Helpers::Token
+            include Helpers::Telemetry
 
             desc 'apps', 'List all applications'
             option :environment, aliases: '--env'
             def apps
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
                   { 'environment' => 'handle' },
@@ -30,6 +33,8 @@ module Aptible
             desc 'apps:create HANDLE', 'Create a new application'
             option :environment, aliases: '--env'
             define_method 'apps:create' do |handle|
+              telemetry(__method__, options)
+
               environment = ensure_environment(options)
               app = environment.create_app(handle: handle)
 
@@ -56,6 +61,8 @@ module Aptible
             option :container_profile, type: :string,
                                        desc: 'Examples: m c r'
             define_method 'apps:scale' do |type|
+              telemetry(__method__, options)
+
               service = ensure_service(options, type)
 
               container_count = options[:container_count]
@@ -89,6 +96,8 @@ module Aptible
             desc 'apps:deprovision', 'Deprovision an app'
             app_options
             define_method 'apps:deprovision' do
+              telemetry(__method__, options)
+
               app = ensure_app(options)
               CLI.logger.info "Deprovisioning #{app.handle}..."
               op = app.create_operation!(type: 'deprovision')
@@ -108,6 +117,8 @@ module Aptible
                  ' drain destinations, you must restart the app.'
             option :environment, aliases: '--env'
             define_method 'apps:rename' do |old_handle, new_handle|
+              telemetry(__method__, options)
+
               env = ensure_environment(options)
               app = ensure_app(options.merge(app: old_handle))
               app.update!(handle: new_handle)

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -6,6 +6,7 @@ module Aptible
           thor.class_eval do
             include Helpers::Token
             include Helpers::Database
+            include Helpers::Telemetry
 
             desc 'backup:restore BACKUP_ID ' \
                  '[--environment ENVIRONMENT_HANDLE] [--handle HANDLE] ' \
@@ -24,6 +25,8 @@ module Aptible
                                        desc: 'Examples: m c r'
             option :iops, type: :numeric
             define_method 'backup:restore' do |backup_id|
+              telemetry(__method__, options)
+
               backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
               raise Thor::Error, "Backup ##{backup_id} not found" if backup.nil?
 
@@ -74,6 +77,8 @@ module Aptible
                    default: '99y',
                    desc: 'Limit backups returned (example usage: 1w, 1y, etc.)'
             define_method 'backup:list' do |handle|
+              telemetry(__method__, options)
+
               age = ChronicDuration.parse(options[:max_age])
               raise Thor::Error, "Invalid age: #{options[:max_age]}" if age.nil?
               min_created_at = Time.now - age
@@ -101,6 +106,8 @@ module Aptible
                              desc: 'Limit backups returned '\
                                    '(example usage: 1w, 1y, etc.)'
             define_method 'backup:orphaned' do
+              telemetry(__method__, options)
+
               age = ChronicDuration.parse(options[:max_age])
               raise Thor::Error, "Invalid age: #{options[:max_age]}" if age.nil?
               min_created_at = Time.now - age
@@ -126,6 +133,8 @@ module Aptible
             desc 'backup:purge BACKUP_ID',
                  'Permanently delete a backup and any copies of it'
             define_method 'backup:purge' do |backup_id|
+              telemetry(__method__, options)
+
               backup = Aptible::Api::Backup.find(backup_id, token: fetch_token)
               raise Thor::Error, "Backup ##{backup_id} not found" if backup.nil?
 

--- a/lib/aptible/cli/subcommands/backup_retention_policy.rb
+++ b/lib/aptible/cli/subcommands/backup_retention_policy.rb
@@ -10,10 +10,13 @@ module Aptible
           thor.class_eval do
             include Helpers::Environment
             include Term::ANSIColor
+            include Helpers::Telemetry
 
             desc 'backup_retention_policy [ENVIRONMENT_HANDLE]',
                  'Show the current backup retention policy for the environment'
             define_method 'backup_retention_policy' do |env|
+              telemetry(__method__, options)
+
               account = ensure_environment(environment: env)
               policy = account.backup_retention_policies.first
               unless policy
@@ -52,6 +55,8 @@ module Aptible
                    desc: 'Do not prompt for confirmation if the new policy ' \
                          'retains fewer backups than the current policy'
             define_method 'backup_retention_policy:set' do |env|
+              telemetry(__method__, options)
+
               if options.empty?
                 raise Thor::Error,
                       'Please specify at least one attribute to change'

--- a/lib/aptible/cli/subcommands/config.rb
+++ b/lib/aptible/cli/subcommands/config.rb
@@ -7,10 +7,13 @@ module Aptible
           thor.class_eval do
             include Helpers::Operation
             include Helpers::App
+            include Helpers::Telemetry
 
             desc 'config', "Print an app's current configuration"
             app_options
             def config
+              telemetry(__method__, options)
+
               app = ensure_app(options)
               config = app.current_configuration
               env = config ? config.env : {}
@@ -32,6 +35,8 @@ module Aptible
                  "Print a specific key within an app's current configuration"
             app_options
             define_method 'config:get' do |*args|
+              telemetry(__method__, options)
+
               app = ensure_app(options)
               config = app.current_configuration
               env = config ? config.env : {}
@@ -49,6 +54,8 @@ module Aptible
                  'Add an ENV variable to an app'
             app_options
             define_method 'config:add' do |*args|
+              telemetry(__method__, options)
+
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
               env = extract_env(args)
@@ -61,6 +68,7 @@ module Aptible
                  'Add an ENV variable to an app'
             app_options
             define_method 'config:set' do |*args|
+              telemetry(__method__, options)
               send('config:add', *args)
             end
 
@@ -68,6 +76,8 @@ module Aptible
                  'Remove an ENV variable from an app'
             app_options
             define_method 'config:rm' do |*args|
+              telemetry(__method__, options)
+
               # FIXME: define_method - ?! Seriously, WTF Thor.
               app = ensure_app(options)
               env = Hash[args.map do |arg|
@@ -84,6 +94,7 @@ module Aptible
                  'Remove an ENV variable from an app'
             app_options
             define_method 'config:unset' do |*args|
+              telemetry(__method__, options)
               send('config:rm', *args)
             end
           end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -12,10 +12,13 @@ module Aptible
             include Helpers::Database
             include Helpers::Token
             include Term::ANSIColor
+            include Helpers::Telemetry
 
             desc 'db:list', 'List all databases'
             option :environment, aliases: '--env'
             define_method 'db:list' do
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
                   { 'environment' => 'handle' },
@@ -34,6 +37,8 @@ module Aptible
 
             desc 'db:versions', 'List available database versions'
             define_method 'db:versions' do
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list('type', 'version') do |node|
                   Aptible::Api::DatabaseImage.all(
@@ -68,6 +73,8 @@ module Aptible
                                        desc: 'Examples: m c r'
             option :iops, type: :numeric
             define_method 'db:create' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
 
               db_opts = {
@@ -128,6 +135,8 @@ module Aptible
             desc 'db:clone SOURCE DEST', 'Clone a database to create a new one'
             option :environment, aliases: '--env'
             define_method 'db:clone' do |source_handle, dest_handle|
+              telemetry(__method__, options)
+
               # TODO: Deprecate + recommend backup
               source = ensure_database(options.merge(db: source_handle))
               database = clone_database(source, dest_handle)
@@ -150,6 +159,8 @@ module Aptible
                                        desc: 'Examples: m c r'
             option :iops, type: :numeric
             define_method 'db:replicate' do |source_handle, dest_handle|
+              telemetry(__method__, options)
+
               source = ensure_database(options.merge(db: source_handle))
 
               if options[:logical]
@@ -193,6 +204,8 @@ module Aptible
                  'Dump a remote database to file'
             option :environment, aliases: '--env'
             define_method 'db:dump' do |handle, *dump_options|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               with_postgres_tunnel(database) do |url|
                 filename = "#{handle}.dump"
@@ -207,6 +220,8 @@ module Aptible
             option :environment, aliases: '--env'
             option :on_error_stop, type: :boolean
             define_method 'db:execute' do |handle, sql_path|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               with_postgres_tunnel(database) do |url|
                 CLI.logger.info "Executing #{sql_path} against #{handle}"
@@ -221,6 +236,8 @@ module Aptible
             option :port, type: :numeric
             option :type, type: :string
             define_method 'db:tunnel' do |handle|
+              telemetry(__method__, options)
+
               desired_port = Integer(options[:port] || 0)
               database = ensure_database(options.merge(db: handle))
 
@@ -264,6 +281,8 @@ module Aptible
             desc 'db:deprovision HANDLE', 'Deprovision a database'
             option :environment, aliases: '--env'
             define_method 'db:deprovision' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               CLI.logger.info "Deprovisioning #{database.handle}..."
               op = database.create_operation!(type: 'deprovision')
@@ -280,6 +299,8 @@ module Aptible
             desc 'db:backup HANDLE', 'Backup a database'
             option :environment, aliases: '--env'
             define_method 'db:backup' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               CLI.logger.info "Backing up #{database.handle}..."
               op = database.create_operation!(type: 'backup')
@@ -289,6 +310,8 @@ module Aptible
             desc 'db:reload HANDLE', 'Reload a database'
             option :environment, aliases: '--env'
             define_method 'db:reload' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               CLI.logger.info "Reloading #{database.handle}..."
               op = database.create_operation!(type: 'reload')
@@ -309,6 +332,8 @@ module Aptible
             option :iops, type: :numeric
             option :volume_type
             define_method 'db:restart' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
 
               opts = {
@@ -339,6 +364,8 @@ module Aptible
             option :iops, type: :numeric
             option :volume_type
             define_method 'db:modify' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
 
               opts = {
@@ -357,6 +384,8 @@ module Aptible
             option :environment, aliases: '--env'
             option :type, type: :string
             define_method 'db:url' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               credential = find_credential(database, options[:type])
 
@@ -373,6 +402,8 @@ module Aptible
                  ' metric drain destinations, you must reload the database.'
             option :environment, aliases: '--env'
             define_method 'db:rename' do |old_handle, new_handle|
+              telemetry(__method__, options)
+
               env = ensure_environment(options)
               db = ensure_database(options.merge(db: old_handle))
               db.update!(handle: new_handle)

--- a/lib/aptible/cli/subcommands/deploy.rb
+++ b/lib/aptible/cli/subcommands/deploy.rb
@@ -18,6 +18,7 @@ module Aptible
           thor.class_eval do
             include Helpers::Operation
             include Helpers::App
+            include Helpers::Telemetry
 
             desc 'deploy [OPTIONS] [VAR1=VAL1] [VAR2=VAL2] [...]',
                  'Deploy an app'
@@ -46,6 +47,8 @@ module Aptible
             end
             app_options
             def deploy(*args)
+              telemetry(__method__, options)
+
               app = ensure_app(options)
 
               git_ref = options[:git_commitish]

--- a/lib/aptible/cli/subcommands/endpoints.rb
+++ b/lib/aptible/cli/subcommands/endpoints.rb
@@ -10,6 +10,7 @@ module Aptible
             include Helpers::Operation
             include Helpers::AppOrDatabase
             include Helpers::Vhost
+            include Helpers::Telemetry
 
             database_create_flags = Helpers::Vhost::OptionSetBuilder.new do
               create!
@@ -20,6 +21,8 @@ module Aptible
                  'Create a Database Endpoint'
             database_create_flags.declare_options(self)
             define_method 'endpoints:database:create' do |handle|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: handle))
               service = database.service
               raise Thor::Error, 'Database is not provisioned' if service.nil?
@@ -42,6 +45,8 @@ module Aptible
                  'Modify a Database Endpoint'
             database_modify_flags.declare_options(self)
             define_method 'endpoints:database:modify' do |hostname|
+              telemetry(__method__, options)
+
               database = ensure_database(options.merge(db: options[:database]))
               vhost = find_vhost(each_service(database), hostname)
               vhost.update!(**database_modify_flags.prepare(database.account,
@@ -59,6 +64,8 @@ module Aptible
                  'Create an App TCP Endpoint'
             tcp_create_flags.declare_options(self)
             define_method 'endpoints:tcp:create' do |type|
+              telemetry(__method__, options)
+
               create_app_vhost(
                 tcp_create_flags, options, type,
                 type: 'tcp', platform: 'elb'
@@ -74,6 +81,8 @@ module Aptible
                  'Modify an App TCP Endpoint'
             tcp_modify_flags.declare_options(self)
             define_method 'endpoints:tcp:modify' do |hostname|
+              telemetry(__method__, options)
+
               modify_app_vhost(tcp_modify_flags, options, hostname)
             end
 
@@ -88,6 +97,8 @@ module Aptible
                  'Create an App TLS Endpoint'
             tls_create_flags.declare_options(self)
             define_method 'endpoints:tls:create' do |type|
+              telemetry(__method__, options)
+
               create_app_vhost(
                 tls_create_flags, options, type,
                 type: 'tls', platform: 'elb'
@@ -104,6 +115,8 @@ module Aptible
                  'Modify an App TLS Endpoint'
             tls_modify_flags.declare_options(self)
             define_method 'endpoints:tls:modify' do |hostname|
+              telemetry(__method__, options)
+
               modify_app_vhost(tls_modify_flags, options, hostname)
             end
 
@@ -118,6 +131,8 @@ module Aptible
                  'Create an App gRPC Endpoint'
             grpc_create_flags.declare_options(self)
             define_method 'endpoints:grpc:create' do |type|
+              telemetry(__method__, options)
+
               create_app_vhost(
                 grpc_create_flags, options, type,
                 type: 'grpc', platform: 'elb'
@@ -134,6 +149,8 @@ module Aptible
                  'Modify an App gRPC Endpoint'
             grpc_modify_flags.declare_options(self)
             define_method 'endpoints:grpc:modify' do |hostname|
+              telemetry(__method__, options)
+
               modify_app_vhost(grpc_modify_flags, options, hostname)
             end
 
@@ -148,6 +165,8 @@ module Aptible
                  'Create an App HTTPS Endpoint'
             https_create_flags.declare_options(self)
             define_method 'endpoints:https:create' do |type|
+              telemetry(__method__, options)
+
               create_app_vhost(
                 https_create_flags, options, type,
                 type: 'http', platform: 'alb'
@@ -164,6 +183,7 @@ module Aptible
                  'Modify an App HTTPS Endpoint'
             https_modify_flags.declare_options(self)
             define_method 'endpoints:https:modify' do |hostname|
+              telemetry(__method__, options)
               modify_app_vhost(https_modify_flags, options, hostname)
             end
 
@@ -171,6 +191,8 @@ module Aptible
                  'List Endpoints for an App or Database'
             app_or_database_options
             define_method 'endpoints:list' do
+              telemetry(__method__, options)
+
               resource = ensure_app_or_database(options)
 
               Formatter.render(Renderer.current) do |root|
@@ -191,6 +213,8 @@ module Aptible
                  'Deprovision an App or Database Endpoint'
             app_or_database_options
             define_method 'endpoints:deprovision' do |hostname|
+              telemetry(__method__, options)
+
               resource = ensure_app_or_database(options)
               vhost = find_vhost(each_service(resource), hostname)
               op = vhost.create_operation!(type: 'deprovision')
@@ -209,6 +233,8 @@ module Aptible
             LONGDESC
             app_options
             define_method 'endpoints:renew' do |hostname|
+              telemetry(__method__, options)
+
               app = ensure_app(options)
               vhost = find_vhost(app.each_service, hostname)
               op = vhost.create_operation!(type: 'renew')

--- a/lib/aptible/cli/subcommands/environment.rb
+++ b/lib/aptible/cli/subcommands/environment.rb
@@ -6,10 +6,13 @@ module Aptible
           thor.class_eval do
             include Helpers::Environment
             include Helpers::Token
+            include Helpers::Telemetry
 
             desc 'environment:list', 'List all environments'
             option :environment, aliases: '--env'
             define_method 'environment:list' do
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.keyed_list(
                   'handle'
@@ -27,6 +30,8 @@ module Aptible
                  'Retrieve the CA certificate associated with the environment'
             option :environment, aliases: '--env'
             define_method 'environment:ca_cert' do
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
                   'handle',
@@ -48,6 +53,8 @@ module Aptible
                  ' destinations, you must restart the apps/databases in'\
                  ' this environment.'
             define_method 'environment:rename' do |old_handle, new_handle|
+              telemetry(__method__, options)
+
               env = ensure_environment(options.merge(environment: old_handle))
               env.update!(handle: new_handle)
               m1 = "In order for the new environment handle (#{new_handle})"\

--- a/lib/aptible/cli/subcommands/log_drain.rb
+++ b/lib/aptible/cli/subcommands/log_drain.rb
@@ -7,6 +7,7 @@ module Aptible
             include Helpers::Token
             include Helpers::Database
             include Helpers::LogDrain
+            include Helpers::Telemetry
 
             drain_flags = '--environment ENVIRONMENT ' \
                           '[--drain-apps true/false] ' \
@@ -25,6 +26,8 @@ module Aptible
             desc 'log_drain:list', 'List all Log Drains'
             option :environment, aliases: '--env'
             define_method 'log_drain:list' do
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
                   { 'environment' => 'handle' },
@@ -49,6 +52,8 @@ module Aptible
             option :db, type: :string
             option :pipeline, type: :string
             define_method 'log_drain:create:elasticsearch' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
               database = ensure_database(options)
 
@@ -73,6 +78,8 @@ module Aptible
             drain_options
             option :url, type: :string
             define_method 'log_drain:create:datadog' do |handle|
+              telemetry(__method__, options)
+
               msg = 'Must be in the format of ' \
                     '"https://http-intake.logs.datadoghq.com' \
                     '/v1/input/<DD_API_KEY>".'
@@ -86,6 +93,7 @@ module Aptible
             option :url, type: :string
             drain_options
             define_method 'log_drain:create:https' do |handle|
+              telemetry(__method__, options)
               create_https_based_log_drain(handle, options)
             end
 
@@ -96,6 +104,7 @@ module Aptible
             option :url, type: :string
             drain_options
             define_method 'log_drain:create:sumologic' do |handle|
+              telemetry(__method__, options)
               create_https_based_log_drain(handle, options)
             end
 
@@ -106,6 +115,8 @@ module Aptible
             option :url, type: :string
             drain_options
             define_method 'log_drain:create:logdna' do |handle|
+              telemetry(__method__, options)
+
               msg = 'Must be in the format of ' \
                     '"https://logs.logdna.com/aptible/ingest/<INGESTION KEY>".'
               create_https_based_log_drain(handle, options, url_format_msg: msg)
@@ -119,6 +130,7 @@ module Aptible
             option :port, type: :string
             drain_options
             define_method 'log_drain:create:papertrail' do |handle|
+              telemetry(__method__, options)
               create_syslog_based_log_drain(handle, options)
             end
 
@@ -132,6 +144,7 @@ module Aptible
             option :token, type: :string
             drain_options
             define_method 'log_drain:create:syslog' do |handle|
+              telemetry(__method__, options)
               create_syslog_based_log_drain(handle, options)
             end
 
@@ -139,6 +152,7 @@ module Aptible
                  'Deprovisions a log drain'
             option :environment, aliases: '--env'
             define_method 'log_drain:deprovision' do |handle|
+              telemetry(__method__, options)
               account = ensure_environment(options)
               drain = ensure_log_drain(account, handle)
               op = drain.create_operation(type: :deprovision)

--- a/lib/aptible/cli/subcommands/logs.rb
+++ b/lib/aptible/cli/subcommands/logs.rb
@@ -12,11 +12,14 @@ module Aptible
             include Helpers::AppOrDatabase
             include Helpers::S3LogHelpers
             include Helpers::DateHelpers
+            include Helpers::Telemetry
 
             desc 'logs [--app APP | --database DATABASE]',
                  'Follows logs from a running app or database'
             app_or_database_options
             def logs
+              telemetry(__method__, options)
+
               resource = ensure_app_or_database(options)
 
               unless resource.status == 'provisioned'
@@ -89,6 +92,8 @@ module Aptible
                    type: :string
 
             def logs_from_archive
+              telemetry(__method__, options)
+
               ensure_aws_creds
               validate_log_search_options(options)
 

--- a/lib/aptible/cli/subcommands/maintenance.rb
+++ b/lib/aptible/cli/subcommands/maintenance.rb
@@ -7,12 +7,15 @@ module Aptible
             include Helpers::Environment
             include Helpers::Maintenance
             include Helpers::Token
+            include Helpers::Telemetry
 
             desc 'maintenance:apps',
                  'List Apps impacted by maintenance schedules where '\
                  'restarts are required'
             option :environment, aliases: '--env'
             define_method 'maintenance:apps' do
+              telemetry(__method__, options)
+
               found_maintenance = false
               m = maintenance_apps
               Formatter.render(Renderer.current) do |root|
@@ -48,6 +51,8 @@ module Aptible
                  'restarts are required'
             option :environment, aliases: '--env'
             define_method 'maintenance:dbs' do
+              telemetry(__method__, options)
+
               found_maintenance = false
               m = maintenance_databases
               Formatter.render(Renderer.current) do |root|

--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -16,10 +16,13 @@ module Aptible
             include Helpers::Token
             include Helpers::Database
             include Helpers::MetricDrain
+            include Helpers::Telemetry
 
             desc 'metric_drain:list', 'List all Metric Drains'
             option :environment, aliases: '--env'
             define_method 'metric_drain:list' do
+              telemetry(__method__, options)
+
               Formatter.render(Renderer.current) do |root|
                 root.grouped_keyed_list(
                   { 'environment' => 'handle' },
@@ -43,6 +46,8 @@ module Aptible
             option :environment, aliases: '--env'
 
             define_method 'metric_drain:create:influxdb' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
               database = ensure_database(options)
 
@@ -68,6 +73,8 @@ module Aptible
             option :db, type: :string
             option :environment, aliases: '--env'
             define_method 'metric_drain:create:influxdb:custom' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
 
               config = {
@@ -97,6 +104,8 @@ module Aptible
             option :url, type: :string
             option :environment, aliases: '--env'
             define_method 'metric_drain:create:influxdb:customv2' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
 
               config = {
@@ -123,6 +132,8 @@ module Aptible
             option :site, type: :string
             option :environment, aliases: '--env'
             define_method 'metric_drain:create:datadog' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
 
               config = {
@@ -152,6 +163,8 @@ module Aptible
                  'Deprovisions a Metric Drain'
             option :environment, aliases: '--env'
             define_method 'metric_drain:deprovision' do |handle|
+              telemetry(__method__, options)
+
               account = ensure_environment(options)
               drain = ensure_metric_drain(account, handle)
               op = drain.create_operation(type: :deprovision)

--- a/lib/aptible/cli/subcommands/operation.rb
+++ b/lib/aptible/cli/subcommands/operation.rb
@@ -6,9 +6,12 @@ module Aptible
           thor.class_eval do
             include Helpers::Token
             include Helpers::Operation
+            include Helpers::Telemetry
 
             desc 'operation:cancel OPERATION_ID', 'Cancel a running operation'
             define_method 'operation:cancel' do |operation_id|
+              telemetry(__method__, options)
+
               o = Aptible::Api::Operation.find(operation_id, token: fetch_token)
               raise "Operation ##{operation_id} not found" if o.nil?
 
@@ -20,6 +23,8 @@ module Aptible
             desc 'operation:follow OPERATION_ID',
                  'Follow logs of a running operation'
             define_method 'operation:follow' do |operation_id|
+              telemetry(__method__, options)
+
               o = Aptible::Api::Operation.find(operation_id, token: fetch_token)
               raise "Operation ##{operation_id} not found" if o.nil?
 
@@ -37,6 +42,8 @@ module Aptible
 
             desc 'operation:logs OPERATION_ID', 'View logs for given operation'
             define_method 'operation:logs' do |operation_id|
+              telemetry(__method__, options)
+
               o = Aptible::Api::Operation.find(operation_id, token: fetch_token)
               raise "Operation ##{operation_id} not found" if o.nil?
 

--- a/lib/aptible/cli/subcommands/rebuild.rb
+++ b/lib/aptible/cli/subcommands/rebuild.rb
@@ -6,10 +6,13 @@ module Aptible
           thor.class_eval do
             include Helpers::Operation
             include Helpers::App
+            include Helpers::Telemetry
 
             desc 'rebuild', 'Rebuild an app, and restart its services'
             app_options
             def rebuild
+              telemetry(__method__, options)
+
               app = ensure_app(options)
               operation = app.create_operation!(type: 'rebuild')
               CLI.logger.info 'Rebuilding app...'

--- a/lib/aptible/cli/subcommands/restart.rb
+++ b/lib/aptible/cli/subcommands/restart.rb
@@ -6,6 +6,7 @@ module Aptible
           thor.class_eval do
             include Helpers::Operation
             include Helpers::App
+            include Helpers::Telemetry
 
             desc 'restart', 'Restart all services associated with an app'
             option :simulate_oom,
@@ -20,6 +21,8 @@ module Aptible
                          'default.'
             app_options
             def restart
+              telemetry(__method__, options)
+
               app = ensure_app(options)
               type = 'restart'
 

--- a/lib/aptible/cli/subcommands/services.rb
+++ b/lib/aptible/cli/subcommands/services.rb
@@ -5,10 +5,13 @@ module Aptible
         def self.included(thor)
           thor.class_eval do
             include Helpers::App
+            include Helpers::Telemetry
 
             desc 'services', 'List Services for an App'
             app_options
             def services
+              telemetry(__method__, options)
+
               app = ensure_app(options)
 
               Formatter.render(Renderer.current) do |root|
@@ -35,6 +38,8 @@ module Aptible
                    type: :boolean, default: false,
                    desc: 'Use a simple uptime healthcheck during deployments'
             define_method 'services:settings' do |service|
+              telemetry(__method__, options)
+
               service = ensure_service(options, service)
               updates = {}
               updates[:force_zero_downtime] =
@@ -49,6 +54,8 @@ module Aptible
                  'Returns the associated sizing policy, if any'
             app_options
             define_method 'services:autoscaling_policy' do |service|
+              telemetry(__method__, options)
+
               service = ensure_service(options, service)
               policy = service.service_sizing_policy
 
@@ -187,6 +194,8 @@ module Aptible
                    ' a value of 2 will go from 4->2->1). Container count '\
                    'will never exceed the configured minimum.'
             define_method 'services:autoscaling_policy:set' do |service|
+              telemetry(__method__, options)
+
               service = ensure_service(options, service)
               ignored_attrs = %i(autoscaling_type app environment remote)
               args = options.except(*ignored_attrs)

--- a/lib/aptible/cli/subcommands/ssh.rb
+++ b/lib/aptible/cli/subcommands/ssh.rb
@@ -8,6 +8,7 @@ module Aptible
           thor.class_eval do
             include Helpers::Operation
             include Helpers::App
+            include Helpers::Telemetry
 
             desc 'ssh [COMMAND]', 'Run a command against an app'
             long_desc <<-LONGDESC
@@ -18,6 +19,8 @@ module Aptible
             app_options
             option :force_tty, type: :boolean
             def ssh(*args)
+              telemetry(__method__, options)
+
               app = ensure_app(options)
 
               # SSH's default behavior is as follows:


### PR DESCRIPTION
This change will make it so all commands run with `aptible-cli` will send a tuna event with the following info:

- user email
- user -or- org id
- format (e.g. text or json)
- command run
- options provided to command

This is the foundation for us to evaluate usage and provide us with the ability to make decisions about the future direction of the CLI.

I tried to find a `before` hook for Thor but it looks like it doesn't exist: https://stackoverflow.com/questions/61855861/is-there-a-way-to-add-hooks-to-a-thor-class-in-order-to-run-code-before-after-al