### PR TITLE
refactor: improve list command performance

### DIFF
--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -1,6 +1,6 @@
 require 'base64'
 require 'uri'
-# require 'logger'
+require 'logger'
 
 require 'aptible/auth'
 require 'thor'
@@ -83,7 +83,10 @@ module Aptible
         nag_toolbelt unless toolbelt?
         Aptible::Resource.configure do |conf|
           conf.user_agent = version_string
-          # conf.logger.tap { |l| l.level = Logger::INFO }
+          level = Logger::WARN
+          debug_level = ENV['APTIBLE_DEBUG']
+          level = debug_level if debug_level
+          conf.logger.tap { |l| l.level = level }
         end
         warn_sso_enforcement
         super

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'uri'
+require 'logger'
 
 require 'aptible/auth'
 require 'thor'
@@ -80,7 +81,10 @@ module Aptible
 
       def initialize(*)
         nag_toolbelt unless toolbelt?
-        Aptible::Resource.configure { |conf| conf.user_agent = version_string }
+        Aptible::Resource.configure do |conf|
+          conf.user_agent = version_string
+          conf.logger.tap { |l| l.level = Logger::INFO }
+        end
         warn_sso_enforcement
         super
       end

--- a/lib/aptible/cli/agent.rb
+++ b/lib/aptible/cli/agent.rb
@@ -1,6 +1,6 @@
 require 'base64'
 require 'uri'
-require 'logger'
+# require 'logger'
 
 require 'aptible/auth'
 require 'thor'
@@ -83,7 +83,7 @@ module Aptible
         nag_toolbelt unless toolbelt?
         Aptible::Resource.configure do |conf|
           conf.user_agent = version_string
-          conf.logger.tap { |l| l.level = Logger::INFO }
+          # conf.logger.tap { |l| l.level = Logger::INFO }
         end
         warn_sso_enforcement
         super

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -151,16 +151,27 @@ module Aptible
           service
         end
 
+        def apps_href
+          href = '/apps'
+          if Renderer.format != 'json'
+            href = '/apps?per_page=5000&no_embed=true'
+          end
+          href
+        end
+
+        def apps_all
+          Aptible::Api::App.all(
+            token: fetch_token,
+            href: apps_href
+          )
+        end
+
         def apps_from_handle(handle, environment)
           # TODO: This should probably use each_app for more efficiency.
           if environment
             environment.apps
           else
-            href = '/apps'
-            if Renderer.format != 'json'
-              href = '/apps?per_page=5000&no_embed=true'
-            end
-            Aptible::Api::App.all(token: fetch_token, href: href)
+            apps_all
           end.select { |a| a.handle == handle }
         end
 

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -156,7 +156,11 @@ module Aptible
           if environment
             environment.apps
           else
-            Aptible::Api::App.all(token: fetch_token)
+            href = '/apps'
+            if Renderer.format != 'json'
+              href = '/apps?per_page=5000&no_embed=true'
+            end
+            Aptible::Api::App.all(token: fetch_token, href: href)
           end.select { |a| a.handle == handle }
         end
 

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -40,18 +40,18 @@ module Aptible
         end
 
         def databases_all
-          databases = Aptible::Api::Database.all(
+          Aptible::Api::Database.all(
             token: fetch_token,
             href: databases_href
           )
         end
 
         def databases_from_handle(handle, environment)
-          if environment
-            databases = environment.databases
-          else
-            databases = databases_all
-          end
+          databases = if environment
+                        environment.databases
+                      else
+                        databases_all
+                      end
           databases.select { |a| a.handle == handle }
         end
 

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -35,7 +35,14 @@ module Aptible
           if environment
             databases = environment.databases
           else
-            databases = Aptible::Api::Database.all(token: fetch_token)
+            href = '/databases'
+            if Renderer.format != 'json'
+              href = '/databases?per_page=5000&no_embed=true'
+            end
+            databases = Aptible::Api::Database.all(
+              token: fetch_token,
+              href: href 
+            )
           end
           databases.select { |a| a.handle == handle }
         end

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -31,18 +31,26 @@ module Aptible
           end
         end
 
+        def databases_href
+          href = '/databases'
+          if Renderer.format != 'json'
+            href = '/databases?per_page=5000&no_embed=true'
+          end
+          href
+        end
+
+        def databases_all
+          databases = Aptible::Api::Database.all(
+            token: fetch_token,
+            href: databases_href
+          )
+        end
+
         def databases_from_handle(handle, environment)
           if environment
             databases = environment.databases
           else
-            href = '/databases'
-            if Renderer.format != 'json'
-              href = '/databases?per_page=5000&no_embed=true'
-            end
-            databases = Aptible::Api::Database.all(
-              token: fetch_token,
-              href: href 
-            )
+            databases = databases_all
           end
           databases.select { |a| a.handle == handle }
         end

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -6,7 +6,7 @@ module Aptible
       module Environment
         include Helpers::Token
 
-        def get_environment_href
+        def environment_href
           href = '/accounts'
           if Renderer.format != 'json'
             href = '/accounts?per_page=5000&no_embed=true'
@@ -22,7 +22,7 @@ module Aptible
               raise Thor::Error, 'Specified account does not exist'
             end
           else
-            href = get_environment_href 
+            href = environment_href
             Aptible::Api::Account.all(
               token: fetch_token,
               href: href
@@ -42,15 +42,14 @@ module Aptible
 
         def environment_from_handle(handle)
           return nil unless handle
-          href = get_environment_href 
-
+          href = environment_href
           Aptible::Api::Account.all(token: fetch_token, href: href).find do |a|
             a.handle == handle
           end
         end
 
         def ensure_default_environment
-          href = get_environment_href 
+          href = environment_href
           environments = Aptible::Api::Account.all(
             token: fetch_token,
             href: href

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -48,6 +48,14 @@ module Aptible
           end
         end
 
+        def environment_map(accounts)
+          acc_map = {}
+          accounts.each do |account|
+            acc_map[account.links.self.href] = account
+          end
+          acc_map
+        end
+
         def ensure_default_environment
           href = environment_href
           environments = Aptible::Api::Account.all(

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -6,7 +6,7 @@ module Aptible
       module Environment
         include Helpers::Token
 
-        def scoped_environments(options)
+        def scoped_environments(options, no_embed=false)
           if options[:environment]
             if (environment = environment_from_handle(options[:environment]))
               [environment]
@@ -14,7 +14,15 @@ module Aptible
               raise Thor::Error, 'Specified account does not exist'
             end
           else
-            Aptible::Api::Account.all(token: fetch_token)
+            href = '/accounts'
+            if no_embed
+              href = '/accounts?per_page=5000&no_embed=true'
+            end
+
+            Aptible::Api::Account.all(
+              token: fetch_token,
+              href: href
+            )
           end
         end
 

--- a/lib/aptible/cli/renderer.rb
+++ b/lib/aptible/cli/renderer.rb
@@ -9,8 +9,12 @@ module Aptible
     module Renderer
       FORMAT_VAR = 'APTIBLE_OUTPUT_FORMAT'.freeze
 
+      def self.format
+        ENV[FORMAT_VAR]
+      end
+
       def self.current
-        case (format = ENV[FORMAT_VAR])
+        case format
         when 'json'
           Json.new
         when 'text'

--- a/lib/aptible/cli/resource_formatter.rb
+++ b/lib/aptible/cli/resource_formatter.rb
@@ -108,6 +108,13 @@ module Aptible
           attach_account(node, account)
         end
 
+        def inject_database_minimal(node, database, account)
+          node.value('id', database.id)
+          node.value('handle', database.handle)
+          node.value('created_at', database.created_at)
+          attach_account(node, account)
+        end
+
         def inject_database(node, database, account)
           node.value('id', database.id)
           node.value('handle', database.handle)

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -16,11 +16,8 @@ module Aptible
                   { 'environment' => 'handle' },
                   'handle'
                 ) do |node|
-                  acc_map = {}
                   accounts = scoped_environments(options)
-                  accounts.each do |account|
-                    acc_map[account.links.self.href] = account
-                  end
+                  acc_map = environment_map(accounts)
 
                   if Renderer.format == 'json'
                     accounts.each do |account|

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -30,6 +30,8 @@ module Aptible
                   else
                     apps_all.each do |app|
                       account = acc_map[app.links.account.href]
+                      next if account.nil?
+
                       node.object do |n|
                         ResourceFormatter.inject_app(n, app, account)
                       end

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -17,7 +17,7 @@ module Aptible
                   'handle'
                 ) do |node|
                   acc_map = {}
-                  accounts = scoped_environments(options, Renderer.format!='json')
+                  accounts = scoped_environments(options)
                   accounts.each do |account|
                     acc_map[account.links.self.href] = account
                   end

--- a/lib/aptible/cli/subcommands/apps.rb
+++ b/lib/aptible/cli/subcommands/apps.rb
@@ -31,10 +31,7 @@ module Aptible
                       end
                     end
                   else
-                    Aptible::Api::App.all(
-                      token: fetch_token,
-                      href: '/apps?per_page=5000&no_embed=true'
-                    ).each do |app|
+                    apps_all.each do |app|
                       account = acc_map[app.links.account.href]
                       node.object do |n|
                         ResourceFormatter.inject_app(n, app, account)

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -36,13 +36,14 @@ module Aptible
                       end
                     end
                   else
-                    Aptible::Api::Database.all(
-                      token: fetch_token,
-                      href: '/databases?per_page=5000&no_embed=true'
-                    ).each do |db|
+                    databases_all.each do |db|
                       account = acc_map[db.links.account.href]
                       node.object do |n|
-                        ResourceFormatter.inject_database_minimal(n, db, account)
+                        ResourceFormatter.inject_database_minimal(
+                          n,
+                          db,
+                          account
+                        )
                       end
                     end
                   end

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -21,11 +21,8 @@ module Aptible
                   { 'environment' => 'handle' },
                   'handle'
                 ) do |node|
-                  acc_map = {}
                   accounts = scoped_environments(options)
-                  accounts.each do |account|
-                    acc_map[account.links.self.href] = account
-                  end
+                  acc_map = environment_map(accounts)
 
                   if Renderer.format == 'json'
                     accounts.each do |account|

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -36,6 +36,7 @@ module Aptible
                     databases_all.each do |db|
                       account = acc_map[db.links.account.href]
                       next if account.nil?
+
                       node.object do |n|
                         ResourceFormatter.inject_database_minimal(
                           n,

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -38,6 +38,7 @@ module Aptible
                   else
                     databases_all.each do |db|
                       account = acc_map[db.links.account.href]
+                      next if account.nil?
                       node.object do |n|
                         ResourceFormatter.inject_database_minimal(
                           n,

--- a/lib/aptible/cli/subcommands/db.rb
+++ b/lib/aptible/cli/subcommands/db.rb
@@ -22,7 +22,7 @@ module Aptible
                   'handle'
                 ) do |node|
                   acc_map = {}
-                  accounts = scoped_environments(options, Renderer.format!='json')
+                  accounts = scoped_environments(options)
                   accounts.each do |account|
                     acc_map[account.links.self.href] = account
                   end

--- a/lib/aptible/cli/subcommands/log_drain.rb
+++ b/lib/aptible/cli/subcommands/log_drain.rb
@@ -30,11 +30,8 @@ module Aptible
                   { 'environment' => 'handle' },
                   'handle'
                 ) do |node|
-                  acc_map = {}
                   accounts = scoped_environments(options)
-                  accounts.each do |account|
-                    acc_map[account.links.self.href] = account
-                  end
+                  acc_map = environment_map(accounts)
 
                   Aptible::Api::LogDrain.all(
                     token: fetch_token,

--- a/lib/aptible/cli/subcommands/log_drain.rb
+++ b/lib/aptible/cli/subcommands/log_drain.rb
@@ -30,11 +30,19 @@ module Aptible
                   { 'environment' => 'handle' },
                   'handle'
                 ) do |node|
-                  scoped_environments(options).each do |account|
-                    account.log_drains.each do |drain|
-                      node.object do |n|
-                        ResourceFormatter.inject_log_drain(n, drain, account)
-                      end
+                  acc_map = {}
+                  accounts = scoped_environments(options)
+                  accounts.each do |account|
+                    acc_map[account.links.self.href] = account
+                  end
+
+                  Aptible::Api::LogDrain.all(
+                    token: fetch_token,
+                    href: '/log_drains?per_page=5000'
+                  ).each do |drain|
+                    account = acc_map[drain.links.account.href]
+                    node.object do |n|
+                      ResourceFormatter.inject_log_drain(n, drain, account)
                     end
                   end
                 end

--- a/lib/aptible/cli/subcommands/log_drain.rb
+++ b/lib/aptible/cli/subcommands/log_drain.rb
@@ -38,6 +38,8 @@ module Aptible
                     href: '/log_drains?per_page=5000'
                   ).each do |drain|
                     account = acc_map[drain.links.account.href]
+                    next if account.nil?
+
                     node.object do |n|
                       ResourceFormatter.inject_log_drain(n, drain, account)
                     end

--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -33,6 +33,8 @@ module Aptible
                     href: '/metric_drains?per_page=5000'
                   ).each do |drain|
                     account = acc_map[drain.links.account.href]
+                    next if account.nil?
+
                     node.object do |n|
                       ResourceFormatter.inject_metric_drain(n, drain, account)
                     end

--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -25,11 +25,19 @@ module Aptible
                   { 'environment' => 'handle' },
                   'handle'
                 ) do |node|
-                  scoped_environments(options).each do |account|
-                    account.metric_drains.each do |drain|
-                      node.object do |n|
-                        ResourceFormatter.inject_metric_drain(n, drain, account)
-                      end
+                  acc_map = {}
+                  accounts = scoped_environments(options)
+                  accounts.each do |account|
+                    acc_map[account.links.self.href] = account
+                  end
+
+                  Aptible::Api::MetricDrain.all(
+                    token: fetch_token,
+                    href: '/metric_drains?per_page=5000'
+                  ).each do |drain|
+                    account = acc_map[drain.links.account.href]
+                    node.object do |n|
+                      ResourceFormatter.inject_metric_drain(n, drain, account)
                     end
                   end
                 end

--- a/lib/aptible/cli/subcommands/metric_drain.rb
+++ b/lib/aptible/cli/subcommands/metric_drain.rb
@@ -25,11 +25,8 @@ module Aptible
                   { 'environment' => 'handle' },
                   'handle'
                 ) do |node|
-                  acc_map = {}
                   accounts = scoped_environments(options)
-                  accounts.each do |account|
-                    acc_map[account.links.self.href] = account
-                  end
+                  acc_map = environment_map(accounts)
 
                   Aptible::Api::MetricDrain.all(
                     token: fetch_token,

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -31,6 +31,9 @@ describe Aptible::CLI::Agent do
   describe '#apps' do
     it 'lists an app in an account' do
       allow(Aptible::Api::Account).to receive(:all).and_return([account])
+      allow(Aptible::Api::App)
+        .to receive(:all)
+        .and_return([app])
       subject.send('apps')
 
       expect(captured_output_text)
@@ -40,8 +43,11 @@ describe Aptible::CLI::Agent do
     it 'lists multiple apps in an account' do
       allow(Aptible::Api::Account).to receive(:all).and_return([account])
       app2 = Fabricate(:app, handle: 'foobar', account: account)
-      subject.send('apps')
+      allow(Aptible::Api::App)
+        .to receive(:all)
+        .and_return([app, app2])
 
+      subject.send('apps')
       expect(captured_output_text)
         .to eq("=== #{account.handle}\n#{app.handle}\n#{app2.handle}\n")
     end
@@ -54,6 +60,9 @@ describe Aptible::CLI::Agent do
       app21 = Fabricate(:app, account: account2, handle: 'app21')
       app22 = Fabricate(:app, account: account2, handle: 'app21')
 
+      allow(Aptible::Api::App)
+        .to receive(:all)
+        .and_return([app11, app21, app22])
       allow(Aptible::Api::Account).to receive(:all)
         .and_return([account1, account2])
 
@@ -77,6 +86,7 @@ describe Aptible::CLI::Agent do
       app2 = Fabricate(:app, account: account2, handle: 'app2')
       allow(subject).to receive(:options)
         .and_return(environment: account2.handle)
+      allow(Aptible::Api::App).to receive(:all).and_return([app2])
 
       allow(Aptible::Api::Account).to receive(:all)
         .and_return([account, account2])
@@ -90,6 +100,7 @@ describe Aptible::CLI::Agent do
       account = Fabricate(:account, handle: 'account')
       app = Fabricate(:app, account: account, handle: 'app')
       allow(Aptible::Api::Account).to receive(:all).and_return([account])
+      allow(Aptible::Api::App).to receive(:all).and_return([app])
 
       s1 = Fabricate(
         :service,
@@ -148,6 +159,7 @@ describe Aptible::CLI::Agent do
       app = Fabricate(:app, account: account, handle: 'app',
                             last_deploy_operation: op)
       allow(Aptible::Api::Account).to receive(:all).and_return([account])
+      allow(Aptible::Api::App).to receive(:all).and_return([app])
 
       expected_json = [
         {

--- a/spec/aptible/cli/subcommands/config_spec.rb
+++ b/spec/aptible/cli/subcommands/config_spec.rb
@@ -9,9 +9,11 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(Aptible::Api::App).to receive(:all)
-      .with(token: token).and_return([app])
+      .with(token: token, href: '/apps?per_page=5000&no_embed=true')
+      .and_return([app])
     allow(Aptible::Api::Account).to receive(:all)
-      .with(token: token).and_return([account])
+      .with(token: token, href: '/apps?per_page=5000&no_embed=true')
+      .and_return([account])
   end
 
   before { allow(subject).to receive(:options) { { app: app.handle } } }

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -269,6 +269,7 @@ describe Aptible::CLI::Agent do
       staging = Fabricate(:account, handle: 'staging')
       prod = Fabricate(:account, handle: 'production')
 
+      dbs = []
       [
         [staging, 'staging-redis-db'],
         [staging, 'staging-postgres-db'],
@@ -276,12 +277,17 @@ describe Aptible::CLI::Agent do
         [prod, 'prod-postgres-db']
       ].each do |a, h|
         d = Fabricate(:database, account: a, handle: h)
+        dbs << d
         Fabricate(:database_credential, database: d)
       end
 
       token = 'the-token'
       allow(subject).to receive(:fetch_token) { token }
-      allow(Aptible::Api::Account).to receive(:all).with(token: token)
+      allow(Aptible::Api::Database).to receive(:all)
+        .with(token: token, href: '/databases?per_page=5000&no_embed=true')
+        .and_return(dbs)
+      allow(Aptible::Api::Account).to receive(:all)
+        .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
     end
 

--- a/spec/aptible/cli/subcommands/endpoints_spec.rb
+++ b/spec/aptible/cli/subcommands/endpoints_spec.rb
@@ -8,7 +8,9 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(subject).to receive(:fetch_token) { token }
-    allow(Aptible::Api::Account).to receive(:all).with(token: token)
+    allow(Aptible::Api::Account)
+      .to receive(:all)
+      .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([a1, a2])
   end
 
@@ -60,7 +62,9 @@ describe Aptible::CLI::Agent do
     let!(:db) { Fabricate(:database, handle: 'mydb', account: a1) }
 
     before do
-      allow(Aptible::Api::Database).to receive(:all).with(token: token)
+      allow(Aptible::Api::Database)
+        .to receive(:all)
+        .with(token: token, href: '/databases?per_page=5000&no_embed=true')
         .and_return([db])
       allow(db).to receive(:class).and_return(Aptible::Api::Database)
       stub_options
@@ -185,7 +189,9 @@ describe Aptible::CLI::Agent do
     let!(:service) { Fabricate(:service, app: app, process_type: 'web') }
 
     before do
-      allow(Aptible::Api::App).to receive(:all).with(token: token)
+      allow(Aptible::Api::App)
+        .to receive(:all)
+        .with(token: token, href: '/apps?per_page=5000&no_embed=true')
         .and_return([app])
       allow(app).to receive(:class).and_return(Aptible::Api::App)
       stub_options

--- a/spec/aptible/cli/subcommands/environment_spec.rb
+++ b/spec/aptible/cli/subcommands/environment_spec.rb
@@ -12,7 +12,9 @@ describe Aptible::CLI::Agent do
 
   before(:each) do
     allow(subject).to receive(:fetch_token) { token }
-    allow(Aptible::Api::Account).to receive(:all).with(token: token)
+    allow(Aptible::Api::Account)
+      .to receive(:all)
+      .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([a1, a2])
   end
 

--- a/spec/aptible/cli/subcommands/log_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/log_drain_spec.rb
@@ -10,8 +10,13 @@ describe Aptible::CLI::Agent do
   before { allow(subject).to receive(:fetch_token).and_return(token) }
 
   before do
+    allow(Aptible::Api::LogDrain).to receive(:all)
+      .with(token: token, href: '/log_drains?per_page=5000')
+      .and_return([log_drain])
+
     allow(Aptible::Api::Account).to receive(:all)
-      .with(token: token).and_return([account])
+      .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
+      .and_return([account])
   end
 
   describe '#log_drain:list' do
@@ -25,8 +30,16 @@ describe Aptible::CLI::Agent do
 
     it 'lists log drains across multiple accounts' do
       other_account = Fabricate(:account)
-      Fabricate(:log_drain, handle: 'test2', account: other_account)
+      other_drain = Fabricate(
+        :log_drain,
+        handle: 'test2',
+        account: other_account
+      )
       accounts = [account, other_account]
+
+      allow(Aptible::Api::LogDrain).to receive(:all)
+        .with(token: token, href: '/log_drains?per_page=5000')
+        .and_return([log_drain, other_drain])
       allow(Aptible::Api::Account).to receive(:all).and_return(accounts)
 
       subject.send('log_drain:list')

--- a/spec/aptible/cli/subcommands/maintenance_spec.rb
+++ b/spec/aptible/cli/subcommands/maintenance_spec.rb
@@ -55,7 +55,7 @@ describe Aptible::CLI::Agent do
       token = 'the-token'
       allow(subject).to receive(:fetch_token) { token }
       allow(Aptible::Api::Account).to receive(:all)
-        .with(token: token)
+        .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
       allow(Aptible::Api::MaintenanceDatabase).to receive(:all)
         .with(token: token)
@@ -123,7 +123,8 @@ describe Aptible::CLI::Agent do
     before do
       token = 'the-token'
       allow(subject).to receive(:fetch_token) { token }
-      allow(Aptible::Api::Account).to receive(:all).with(token: token)
+      allow(Aptible::Api::Account).to receive(:all)
+        .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
       allow(Aptible::Api::MaintenanceApp).to receive(:all).with(token: token)
         .and_return(maintenance_apps)

--- a/spec/aptible/cli/subcommands/services_spec.rb
+++ b/spec/aptible/cli/subcommands/services_spec.rb
@@ -6,7 +6,9 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(subject).to receive(:fetch_token) { token }
-    allow(Aptible::Api::App).to receive(:all).with(token: token)
+    allow(Aptible::Api::App)
+      .to receive(:all)
+      .with(token: token, href: '/apps?per_page=5000&no_embed=true')
       .and_return([app])
   end
 

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -30,4 +30,12 @@ Fabricator(:account, from: :stub_account) do
   metric_drains { [] }
   backup_retention_policies { [] }
   created_at { Time.now }
+  links do |attrs|
+    hash = {
+      self: OpenStruct.new(
+        href: "/accounts/#{attrs[:id]}"
+      )
+    }
+    OpenStruct.new(hash)
+  end
 end

--- a/spec/fabricators/app_fabricator.rb
+++ b/spec/fabricators/app_fabricator.rb
@@ -31,5 +31,14 @@ Fabricator(:app, from: :stub_app) do
   errors { Aptible::Resource::Errors.new }
   created_at { Time.now }
 
+  links do |attrs|
+    hash = {
+      account: OpenStruct.new(
+        href: "/accounts/#{attrs[:account].id}"
+      )
+    }
+    OpenStruct.new(hash)
+  end
+
   after_create { |app| app.account.apps << app }
 end

--- a/spec/fabricators/database_fabricator.rb
+++ b/spec/fabricators/database_fabricator.rb
@@ -19,6 +19,14 @@ Fabricator(:database, from: :stub_database) do
   database_image
   disk { Fabricate(:database_disk) }
   service { nil }
+  links do |attrs|
+    hash = {
+      account: OpenStruct.new(
+        href: "/accounts/#{attrs[:account].id}"
+      )
+    }
+    OpenStruct.new(hash)
+  end
 
   backups { [] }
   database_credentials { [] }

--- a/spec/fabricators/log_drain_fabricator.rb
+++ b/spec/fabricators/log_drain_fabricator.rb
@@ -16,6 +16,14 @@ end
 Fabricator(:log_drain, from: :stub_log_drain) do
   id { sequence(:log_drain_id) }
   account
+  links do |attrs|
+    hash = {
+      account: OpenStruct.new(
+        href: "/accounts/#{attrs[:account].id}"
+      )
+    }
+    OpenStruct.new(hash)
+  end
 
   after_create { |drain| drain.account.log_drains << drain }
 end

--- a/spec/fabricators/metric_drain_fabricator.rb
+++ b/spec/fabricators/metric_drain_fabricator.rb
@@ -3,6 +3,14 @@ class StubMetricDrain < OpenStruct; end
 Fabricator(:metric_drain, from: :stub_metric_drain) do
   id { sequence(:metric_drain_id) }
   account
+  links do |attrs|
+    hash = {
+      account: OpenStruct.new(
+        href: "/accounts/#{attrs[:account].id}"
+      )
+    }
+    OpenStruct.new(hash)
+  end
 
   after_create { |drain| drain.account.metric_drains << drain }
 end


### PR DESCRIPTION
https://app.shortcut.com/aptible/story/30651/cli-performance-for-list-commands

# environment:list

## before

```bash
$ time bundle exec bin/aptible environment:list

________________________________________________________
Executed in    2.84 secs      fish           external
   usr time  426.77 millis    0.25 millis  426.53 millis
   sys time  139.25 millis    1.70 millis  137.55 millis

```

## after

```bash
$ time bundle exec bin/aptible environment:list

________________________________________________________
Executed in    2.93 secs      fish           external
   usr time  383.18 millis    0.24 millis  382.94 millis
   sys time  142.15 millis    1.64 millis  140.51 millis
```

# apps

## before

```bash
$ time bundle exec bin/aptible apps

________________________________________________________
Executed in   14.55 secs    fish           external
   usr time    1.26 secs    0.26 millis    1.26 secs
   sys time    0.21 secs    1.70 millis    0.21 secs
```

## after

```bash
$ time bundle exec bin/aptible apps

________________________________________________________
Executed in    5.86 secs      fish           external
   usr time  600.29 millis    0.23 millis  600.06 millis
   sys time  200.44 millis    1.54 millis  198.90 millis
```

# db:list

## before

```bash
$ time bundle exec bin/aptible db:list

________________________________________________________
Executed in   47.10 secs    fish           external
   usr time    2.00 secs    0.24 millis    2.00 secs
   sys time    0.38 secs    1.75 millis    0.38 secs
```

## after

```bash
$ time bundle exec bin/aptible db:list

________________________________________________________
Executed in    4.86 secs      fish           external
   usr time  495.17 millis    0.22 millis  494.95 millis
   sys time  143.12 millis    1.48 millis  141.64 millis
```