### PR TITLE
Skip logic if service does not exist

### DIFF
--- a/lib/aptible/cli/subcommands/endpoints.rb
+++ b/lib/aptible/cli/subcommands/endpoints.rb
@@ -198,6 +198,7 @@ module Aptible
               Formatter.render(Renderer.current) do |root|
                 root.list do |list|
                   each_service(resource) do |service|
+                    next if service.nil?
                     service.each_vhost do |vhost|
                       list.object do |node|
                         ResourceFormatter.inject_vhost(node, vhost, service)


### PR DESCRIPTION
If a service doesn't exist, attempting to list vhosts for said service errors out. 

Skip attempting to list/find vhosts for services that don't exist in `endpoint:list`. 