### PR TITLE
Look up handles without listing all resources

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aptible-cli (0.26.4)
+    aptible-cli (0.26.5)
       activesupport (>= 4.0, < 6.0)
       aptible-api (~> 1.12)
       aptible-auth (~> 1.4)

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -167,12 +167,23 @@ module Aptible
         end
 
         def apps_from_handle(handle, environment)
-          # TODO: This should probably use each_app for more efficiency.
-          if environment
-            environment.apps
-          else
-            apps_all
-          end.select { |a| a.handle == handle }
+          url = "/search/app?handle=#{handle}"
+          url += "&environment=#{environment.handle}" unless environment.nil?
+
+          begin
+            app = Aptible::Api::App.find_by_url(
+              url,
+              token: fetch_token
+            )
+
+            return [] if app.nil?
+
+            return [app]
+          rescue => e
+            return [nil, nil] if e.body['error'] == 'multiple_resources_found'
+          end
+
+          []
         end
 
         def extract_env(args)

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -162,7 +162,7 @@ module Aptible
         end
 
         def app_from_handle(handle, environment)
-          url = "/search/app?handle=#{handle}"
+          url = "/find/app?handle=#{handle}"
           url += "&environment=#{environment.handle}" unless environment.nil?
 
           Aptible::Api::App.find_by_url(

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -169,9 +169,8 @@ module Aptible
             url,
             token: fetch_token
           )
-        rescue StandardError => e
-          raise unless e.respond_to?(:body) &&
-                       e.body.is_a?(Hash) &&
+        rescue HyperResource::ClientError => e
+          raise unless e.body.is_a?(Hash) &&
                        e.body['error'] == 'multiple_resources_found'
           raise Thor::Error,
                 "Multiple apps named #{handle} exist, please specify " \

--- a/lib/aptible/cli/helpers/app.rb
+++ b/lib/aptible/cli/helpers/app.rb
@@ -110,12 +110,9 @@ module Aptible
             end
           end
 
-          apps = apps_from_handle(s.app_handle, environment)
+          app = app_from_handle(s.app_handle, environment)
 
-          case apps.count
-          when 1
-            return apps.first
-          when 0
+          if app.nil?
             err_bits = ['Could not find app', s.app_handle]
             if environment
               err_bits << 'in environment'
@@ -125,11 +122,9 @@ module Aptible
             end
             err_bits << s.explain
             raise Thor::Error, err_bits.join(' ')
-          else
-            err = "Multiple apps named #{s.app_handle} exist, please specify " \
-                  'with --environment'
-            raise Thor::Error, err
           end
+
+          app
         end
 
         def ensure_service(options, type)
@@ -166,24 +161,21 @@ module Aptible
           )
         end
 
-        def apps_from_handle(handle, environment)
+        def app_from_handle(handle, environment)
           url = "/search/app?handle=#{handle}"
           url += "&environment=#{environment.handle}" unless environment.nil?
 
-          begin
-            app = Aptible::Api::App.find_by_url(
-              url,
-              token: fetch_token
-            )
-
-            return [] if app.nil?
-
-            return [app]
-          rescue => e
-            return [nil, nil] if e.body['error'] == 'multiple_resources_found'
-          end
-
-          []
+          Aptible::Api::App.find_by_url(
+            url,
+            token: fetch_token
+          )
+        rescue StandardError => e
+          raise unless e.respond_to?(:body) &&
+                       e.body.is_a?(Hash) &&
+                       e.body['error'] == 'multiple_resources_found'
+          raise Thor::Error,
+                "Multiple apps named #{handle} exist, please specify " \
+                'with --environment'
         end
 
         def extract_env(args)

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -142,9 +142,8 @@ module Aptible
             url,
             token: fetch_token
           )
-        rescue StandardError => e
-          raise unless e.respond_to?(:body) &&
-                       e.body.is_a?(Hash) &&
+        rescue HyperResource::ClientError => e
+          raise unless e.body.is_a?(Hash) &&
                        e.body['error'] == 'multiple_resources_found'
           raise Thor::Error,
                 'Multiple databases exist, please specify ' \

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -135,7 +135,7 @@ module Aptible
         end
 
         def database_from_handle(handle, environment)
-          url = "/search/database?handle=#{handle}"
+          url = "/find/database?handle=#{handle}"
           url += "&environment=#{environment.handle}" unless environment.nil?
 
           Aptible::Api::Database.find_by_url(

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -141,12 +141,23 @@ module Aptible
         end
 
         def databases_from_handle(handle, environment)
-          databases = if environment
-                        environment.databases
-                      else
-                        databases_all
-                      end
-          databases.select { |a| a.handle == handle }
+          url = "/search/database?handle=#{handle}"
+          url += "&environment=#{environment.handle}" unless environment.nil?
+
+          begin
+            db = Aptible::Api::Database.find_by_url(
+              url,
+              token: fetch_token
+            )
+
+            return [] if db.nil?
+
+            return [db]
+          rescue => e
+            return [nil, nil] if e.body['error'] == 'multiple_resources_found'
+          end
+
+          []
         end
 
         def clone_database(source, dest_handle)

--- a/lib/aptible/cli/helpers/database.rb
+++ b/lib/aptible/cli/helpers/database.rb
@@ -36,16 +36,10 @@ module Aptible
             raise Thor::Error,
                   "Could not find environment #{environment_handle}"
           end
-          databases = databases_from_handle(db_handle, environment)
-          case databases.count
-          when 1
-            return databases.first
-          when 0
-            raise Thor::Error, "Could not find database #{db_handle}"
-          else
-            err = 'Multiple databases exist, please specify with --environment'
-            raise Thor::Error, err
-          end
+          db = database_from_handle(db_handle, environment)
+          raise Thor::Error, "Could not find database #{db_handle}" if db.nil?
+
+          db
         end
 
         def databases_href
@@ -140,31 +134,28 @@ module Aptible
           external_rds_databases_all.find { |a| a.handle == handle }
         end
 
-        def databases_from_handle(handle, environment)
+        def database_from_handle(handle, environment)
           url = "/search/database?handle=#{handle}"
           url += "&environment=#{environment.handle}" unless environment.nil?
 
-          begin
-            db = Aptible::Api::Database.find_by_url(
-              url,
-              token: fetch_token
-            )
-
-            return [] if db.nil?
-
-            return [db]
-          rescue => e
-            return [nil, nil] if e.body['error'] == 'multiple_resources_found'
-          end
-
-          []
+          Aptible::Api::Database.find_by_url(
+            url,
+            token: fetch_token
+          )
+        rescue StandardError => e
+          raise unless e.respond_to?(:body) &&
+                       e.body.is_a?(Hash) &&
+                       e.body['error'] == 'multiple_resources_found'
+          raise Thor::Error,
+                'Multiple databases exist, please specify ' \
+                'with --environment'
         end
 
         def clone_database(source, dest_handle)
           op = source.create_operation!(type: 'clone', handle: dest_handle)
           attach_to_operation_logs(op)
 
-          databases_from_handle(dest_handle, source.account).first
+          database_from_handle(dest_handle, source.account)
         end
 
         def replicate_database(source, dest_handle, options)
@@ -188,7 +179,7 @@ module Aptible
           op = source.create_operation!(replication_params)
           attach_to_operation_logs(op)
 
-          replica = databases_from_handle(dest_handle, source.account).first
+          replica = database_from_handle(dest_handle, source.account)
           attach_to_operation_logs(replica.operations.last)
           replica
         end

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -42,10 +42,11 @@ module Aptible
 
         def environment_from_handle(handle)
           return nil unless handle
-          href = environment_href
-          Aptible::Api::Account.all(token: fetch_token, href: href).find do |a|
-            a.handle == handle
-          end
+
+          Aptible::Api::Account.find_by_url(
+            "/search/account?handle=#{handle}",
+            token: fetch_token
+          )
         end
 
         def environment_map(accounts)

--- a/lib/aptible/cli/helpers/environment.rb
+++ b/lib/aptible/cli/helpers/environment.rb
@@ -44,7 +44,7 @@ module Aptible
           return nil unless handle
 
           Aptible::Api::Account.find_by_url(
-            "/search/account?handle=#{handle}",
+            "/find/account?handle=#{handle}",
             token: fetch_token
           )
         end

--- a/lib/aptible/cli/subcommands/backup.rb
+++ b/lib/aptible/cli/subcommands/backup.rb
@@ -67,7 +67,7 @@ module Aptible
 
               account = destination_account || backup.account
 
-              database = databases_from_handle(handle, account).first
+              database = database_from_handle(handle, account)
               render_database(database, account)
             end
 

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.26.4'.freeze
+    VERSION = '0.26.5'.freeze
   end
 end

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -20,13 +20,14 @@ describe Aptible::CLI::Agent do
   before do
     allow(subject).to receive(:save_token)
     allow(subject).to receive(:attach_to_operation_logs)
-    allow(subject).to receive(:fetch_token) { double 'token' }
+    allow(subject).to receive(:fetch_token) { token }
   end
 
   let!(:account) { Fabricate(:account) }
   let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
   let!(:service) { Fabricate(:service, app: app, process_type: 'web') }
   let(:op) { Fabricate(:operation, status: 'succeeded', resource: app) }
+  let(:token) { double 'token' }
 
   describe '#apps' do
     it 'lists an app in an account' do
@@ -215,8 +216,12 @@ describe Aptible::CLI::Agent do
 
   describe '#apps:rename' do
     before do
-      allow(Aptible::Api::App).to receive(:all) { [app] }
       allow(Aptible::Api::Account).to receive(:all) { [account] }
+      allow(Aptible::Api::App).to receive(:find_by_url)
+        .and_return(nil)
+      allow(Aptible::Api::App).to receive(:find_by_url)
+        .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
+        .and_return(app)
     end
 
     before(:each) do
@@ -256,7 +261,6 @@ describe Aptible::CLI::Agent do
 
   describe '#apps:scale' do
     before do
-      allow(Aptible::Api::App).to receive(:all) { [app] }
       allow(Aptible::Api::Account).to receive(:all) { [account] }
     end
 
@@ -394,7 +398,14 @@ describe Aptible::CLI::Agent do
 
       before do
         account.apps = apps
-        allow(Aptible::Api::App).to receive(:all).and_return(apps)
+        allow(Aptible::Api::App).to receive(:find_by_url)
+          .and_return(nil)
+        allow(Aptible::Api::App).to receive(:find_by_url)
+          .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
+          .and_return(app)
+        allow(Aptible::Api::App).to receive(:find_by_url)
+          .with("/search/app?handle=#{app.handle}", token: token)
+          .and_return(app)
       end
 
       it 'scopes the app search to an environment if provided' do
@@ -415,27 +426,21 @@ describe Aptible::CLI::Agent do
       end
 
       it 'fails if no app is found' do
-        apps.pop
-
-        strategies = [dummy_strategy_factory('hello', nil, true)]
+        strategies = [dummy_strategy_factory('goodbye', nil, true)]
         allow(subject).to receive(:handle_strategies) { strategies }
 
-        expect { subject.ensure_app }.to raise_error(/not find app hello/)
+        expect { subject.ensure_app }.to raise_error(/not find app goodbye/)
       end
 
       it 'explains the strategy when it fails' do
-        apps.pop
-
-        strategies = [dummy_strategy_factory('hello', nil, true)]
+        strategies = [dummy_strategy_factory('goodbye', nil, true)]
         allow(subject).to receive(:handle_strategies) { strategies }
 
         expect { subject.ensure_app }.to raise_error(/from dummy/)
       end
 
       it 'indicates the environment when the app search was scoped' do
-        apps.pop
-
-        strategies = [dummy_strategy_factory('hello', 'aptible', true)]
+        strategies = [dummy_strategy_factory('goodbye', 'aptible', true)]
         allow(subject).to receive(:handle_strategies) { strategies }
 
         expect(subject).to receive(:environment_from_handle).with('aptible')
@@ -445,7 +450,12 @@ describe Aptible::CLI::Agent do
       end
 
       it 'fails if multiple apps are found' do
-        apps << Fabricate(:app, handle: 'hello')
+        error = StandardError.new('multiple resources found')
+        allow(error).to receive(:body)
+          .and_return('error' => 'multiple_resources_found')
+        allow(Aptible::Api::App).to receive(:find_by_url)
+          .with('/search/app?handle=hello', token: token)
+          .and_raise(error)
 
         strategies = [dummy_strategy_factory('hello', nil, true)]
         allow(subject).to receive(:handle_strategies) { strategies }

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -21,6 +21,9 @@ describe Aptible::CLI::Agent do
     allow(subject).to receive(:save_token)
     allow(subject).to receive(:attach_to_operation_logs)
     allow(subject).to receive(:fetch_token) { token }
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{account.handle}", token: token)
+      .and_return(account)
   end
 
   let!(:account) { Fabricate(:account) }
@@ -84,13 +87,14 @@ describe Aptible::CLI::Agent do
 
     it 'lists filters down to one account' do
       account2 = Fabricate(:account, handle: 'account2')
+      allow(Aptible::Api::Account).to receive(:find_by_url)
+        .with("/search/account?handle=#{account2.handle}", token: token)
+        .and_return(account2)
       app2 = Fabricate(:app, account: account2, handle: 'app2')
       allow(subject).to receive(:options)
         .and_return(environment: account2.handle)
       allow(Aptible::Api::App).to receive(:all).and_return([app2])
 
-      allow(Aptible::Api::Account).to receive(:all)
-        .and_return([account, account2])
       subject.send('apps')
 
       expect(captured_output_text)
@@ -216,7 +220,6 @@ describe Aptible::CLI::Agent do
 
   describe '#apps:rename' do
     before do
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
       allow(Aptible::Api::App).to receive(:find_by_url)
         .and_return(nil)
       allow(Aptible::Api::App).to receive(:find_by_url)
@@ -334,7 +337,7 @@ describe Aptible::CLI::Agent do
       allow(subject).to receive(:options) do
         { environment: 'foo', app: 'web', container_count: 2 }
       end
-      allow(Aptible::Api::Account).to receive(:all) { [] }
+      allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil)
       allow(service).to receive(:create_operation!) { op }
 
       expect do

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -453,7 +453,7 @@ describe Aptible::CLI::Agent do
       end
 
       it 'fails if multiple apps are found' do
-        error = StandardError.new('multiple resources found')
+        error = HyperResource::ClientError.new('multiple resources found')
         allow(error).to receive(:body)
           .and_return('error' => 'multiple_resources_found')
         allow(Aptible::Api::App).to receive(:find_by_url)

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -22,7 +22,7 @@ describe Aptible::CLI::Agent do
     allow(subject).to receive(:attach_to_operation_logs)
     allow(subject).to receive(:fetch_token) { token }
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{account.handle}", token: token)
+      .with("/find/account?handle=#{account.handle}", token: token)
       .and_return(account)
   end
 
@@ -88,7 +88,7 @@ describe Aptible::CLI::Agent do
     it 'lists filters down to one account' do
       account2 = Fabricate(:account, handle: 'account2')
       allow(Aptible::Api::Account).to receive(:find_by_url)
-        .with("/search/account?handle=#{account2.handle}", token: token)
+        .with("/find/account?handle=#{account2.handle}", token: token)
         .and_return(account2)
       app2 = Fabricate(:app, account: account2, handle: 'app2')
       allow(subject).to receive(:options)
@@ -223,7 +223,7 @@ describe Aptible::CLI::Agent do
       allow(Aptible::Api::App).to receive(:find_by_url)
         .and_return(nil)
       allow(Aptible::Api::App).to receive(:find_by_url)
-        .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
+        .with("/find/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
         .and_return(app)
     end
 
@@ -404,10 +404,10 @@ describe Aptible::CLI::Agent do
         allow(Aptible::Api::App).to receive(:find_by_url)
           .and_return(nil)
         allow(Aptible::Api::App).to receive(:find_by_url)
-          .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
+          .with("/find/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
           .and_return(app)
         allow(Aptible::Api::App).to receive(:find_by_url)
-          .with("/search/app?handle=#{app.handle}", token: token)
+          .with("/find/app?handle=#{app.handle}", token: token)
           .and_return(app)
       end
 
@@ -457,7 +457,7 @@ describe Aptible::CLI::Agent do
         allow(error).to receive(:body)
           .and_return('error' => 'multiple_resources_found')
         allow(Aptible::Api::App).to receive(:find_by_url)
-          .with('/search/app?handle=hello', token: token)
+          .with('/find/app?handle=hello', token: token)
           .and_raise(error)
 
         strategies = [dummy_strategy_factory('hello', nil, true)]

--- a/spec/aptible/cli/subcommands/apps_spec.rb
+++ b/spec/aptible/cli/subcommands/apps_spec.rb
@@ -272,9 +272,9 @@ describe Aptible::CLI::Agent do
           .with('foobar')
           .and_return(account)
 
-        expect(subject).to receive(:apps_from_handle)
+        expect(subject).to receive(:app_from_handle)
           .with('hello', account)
-          .and_return([app])
+          .and_return(app)
       end
 
       def stub_options(**opts)

--- a/spec/aptible/cli/subcommands/backup_retention_policy_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_retention_policy_spec.rb
@@ -14,7 +14,7 @@ describe Aptible::CLI::Agent do
   before do
     allow(subject).to receive(:fetch_token).and_return(token)
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{account.handle}", token: token)
+      .with("/find/account?handle=#{account.handle}", token: token)
       .and_return(account)
   end
 

--- a/spec/aptible/cli/subcommands/backup_retention_policy_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_retention_policy_spec.rb
@@ -13,7 +13,9 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(subject).to receive(:fetch_token).and_return(token)
-    allow(Aptible::Api::Account).to receive(:all) { [account] }
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{account.handle}", token: token)
+      .and_return(account)
   end
 
   describe '#backup_retention_policy' do

--- a/spec/aptible/cli/subcommands/backup_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_spec.rb
@@ -21,22 +21,22 @@ describe Aptible::CLI::Agent do
   before do
     allow(subject).to receive(:fetch_token).and_return(token)
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{account.handle}", token: token)
+      .with("/find/account?handle=#{account.handle}", token: token)
       .and_return(account)
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{alt_account.handle}", token: token)
+      .with("/find/account?handle=#{alt_account.handle}", token: token)
       .and_return(alt_account)
     allow(Aptible::Api::Database).to receive(:find_by_url)
-      .with("/search/database?handle=#{default_handle}", token: token)
+      .with("/find/database?handle=#{default_handle}", token: token)
       .and_return(database)
     allow(Aptible::Api::Database).to receive(:find_by_url)
-      .with("/search/database?handle=#{default_handle}&environment=#{account.handle}", token: token)
+      .with("/find/database?handle=#{default_handle}&environment=#{account.handle}", token: token)
       .and_return(database)
     allow(Aptible::Api::Database).to receive(:find_by_url)
-      .with("/search/database?handle=#{database.handle}", token: token)
+      .with("/find/database?handle=#{database.handle}", token: token)
       .and_return(database)
     allow(Aptible::Api::Database).to receive(:find_by_url)
-      .with("/search/database?handle=#{database.handle}&environment=#{account.handle}", token: token)
+      .with("/find/database?handle=#{database.handle}&environment=#{account.handle}", token: token)
       .and_return(database)
   end
 
@@ -80,7 +80,7 @@ describe Aptible::CLI::Agent do
         restored = Fabricate(:database, account: account, handle: h)
 
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{h}&environment=#{account.handle}", token: token)
+          .with("/find/database?handle=#{h}&environment=#{account.handle}", token: token)
           .and_return(database)
 
         expect(backup).to receive(:create_operation!) do |options|
@@ -166,7 +166,7 @@ describe Aptible::CLI::Agent do
 
         subject.options = { environment: 'alt' }
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{default_handle}&environment=alt", token: token)
+          .with("/find/database?handle=#{default_handle}&environment=alt", token: token)
           .and_return(database)
         subject.send('backup:restore', 1)
       end

--- a/spec/aptible/cli/subcommands/backup_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_spec.rb
@@ -21,6 +21,18 @@ describe Aptible::CLI::Agent do
   before do
     allow(subject).to receive(:fetch_token).and_return(token)
     allow(Aptible::Api::Account).to receive(:all) { [account, alt_account] }
+    allow(Aptible::Api::Database).to receive(:find_by_url)
+      .with("/search/database?handle=#{default_handle}", token: token)
+      .and_return(database)
+    allow(Aptible::Api::Database).to receive(:find_by_url)
+      .with("/search/database?handle=#{default_handle}&environment=#{account.handle}", token: token)
+      .and_return(database)
+    allow(Aptible::Api::Database).to receive(:find_by_url)
+      .with("/search/database?handle=#{database.handle}", token: token)
+      .and_return(database)
+    allow(Aptible::Api::Database).to receive(:find_by_url)
+      .with("/search/database?handle=#{database.handle}&environment=#{account.handle}", token: token)
+      .and_return(database)
   end
 
   describe '#backup:restore' do
@@ -60,6 +72,11 @@ describe Aptible::CLI::Agent do
 
       it 'accepts a handle' do
         h = 'some-handle'
+        restored = Fabricate(:database, account: account, handle: h)
+
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{h}&environment=#{account.handle}", token: token)
+          .and_return(database)
 
         expect(backup).to receive(:create_operation!) do |options|
           expect(options[:handle]).to eq(h)
@@ -70,7 +87,7 @@ describe Aptible::CLI::Agent do
         end
 
         expect(subject).to receive(:attach_to_operation_logs).with(op) do
-          Fabricate(:database, account: account, handle: h)
+          restored
         end
 
         subject.options = { handle: h }
@@ -143,6 +160,9 @@ describe Aptible::CLI::Agent do
         end
 
         subject.options = { environment: 'alt' }
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{default_handle}&environment=alt", token: token)
+          .and_return(database)
         subject.send('backup:restore', 1)
       end
     end
@@ -150,7 +170,6 @@ describe Aptible::CLI::Agent do
 
   describe '#backup:list' do
     before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
-    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
 
     before do
       m = allow(database).to receive(:each_backup)
@@ -192,6 +211,7 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('backup:list', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end

--- a/spec/aptible/cli/subcommands/backup_spec.rb
+++ b/spec/aptible/cli/subcommands/backup_spec.rb
@@ -20,7 +20,12 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(subject).to receive(:fetch_token).and_return(token)
-    allow(Aptible::Api::Account).to receive(:all) { [account, alt_account] }
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{account.handle}", token: token)
+      .and_return(account)
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{alt_account.handle}", token: token)
+      .and_return(alt_account)
     allow(Aptible::Api::Database).to receive(:find_by_url)
       .with("/search/database?handle=#{default_handle}", token: token)
       .and_return(database)

--- a/spec/aptible/cli/subcommands/config_spec.rb
+++ b/spec/aptible/cli/subcommands/config_spec.rb
@@ -9,7 +9,7 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(Aptible::Api::App).to receive(:find_by_url)
-      .with("/search/app?handle=#{app.handle}", token: token)
+      .with("/find/app?handle=#{app.handle}", token: token)
       .and_return(app)
     allow(Aptible::Api::Account).to receive(:all)
       .with(token: token, href: '/apps?per_page=5000&no_embed=true')

--- a/spec/aptible/cli/subcommands/config_spec.rb
+++ b/spec/aptible/cli/subcommands/config_spec.rb
@@ -8,9 +8,9 @@ describe Aptible::CLI::Agent do
   before { allow(subject).to receive(:fetch_token).and_return(token) }
 
   before do
-    allow(Aptible::Api::App).to receive(:all)
-      .with(token: token, href: '/apps?per_page=5000&no_embed=true')
-      .and_return([app])
+    allow(Aptible::Api::App).to receive(:find_by_url)
+      .with("/search/app?handle=#{app.handle}", token: token)
+      .and_return(app)
     allow(Aptible::Api::Account).to receive(:all)
       .with(token: token, href: '/apps?per_page=5000&no_embed=true')
       .and_return([account])

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -377,6 +377,9 @@ describe Aptible::CLI::Agent do
       allow(Aptible::Api::Account).to receive(:all)
         .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
+      allow(Aptible::Api::Account).to receive(:find_by_url)
+        .with("/search/account?handle=#{staging.handle}", token: token)
+        .and_return(staging)
       allow(Aptible::Api::ExternalAwsResource).to receive(:all)
         .with(token: token)
         .and_return([])
@@ -412,6 +415,7 @@ describe Aptible::CLI::Agent do
     end
 
     context 'when an invalid account is specified' do
+      before { allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil) }
       it 'prints out an error' do
         subject.options = { environment: 'foo' }
         expect { subject.send('db:list') }
@@ -550,6 +554,9 @@ describe Aptible::CLI::Agent do
       allow(Aptible::Api::Account).to receive(:all)
         .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
+      allow(Aptible::Api::Account).to receive(:find_by_url)
+        .with("/search/account?handle=#{staging.handle}", token: token)
+        .and_return(staging)
       allow(Aptible::Api::ExternalAwsResource).to receive(:all)
         .with(token: token)
         .and_return([staging_rds, prod_rds, unattached_rds])
@@ -1401,7 +1408,9 @@ describe Aptible::CLI::Agent do
     before do
       allow(subject).to receive(:options)
         .and_return(environment: account.handle)
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
+      allow(Aptible::Api::Account).to receive(:find_by_url)
+        .with("/search/account?handle=#{account.handle}", token: token)
+        .and_return(account)
     end
     context 'with environment and db' do
       it 'should rename properly' do

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -819,7 +819,7 @@ describe Aptible::CLI::Agent do
       end
 
       it 'fails if multiple DBs are found' do
-        error = StandardError.new('multiple resources found')
+        error = HyperResource::ClientError.new('multiple resources found')
         allow(error).to receive(:body)
           .and_return('error' => 'multiple_resources_found')
         allow(Aptible::Api::Database).to receive(:find_by_url)

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -14,10 +14,10 @@ describe Aptible::CLI::Agent do
       database.database_credentials
     end
     allow(Aptible::Api::Database).to receive(:find_by_url)
-      .with("/search/database?handle=#{handle}", token: token)
+      .with("/find/database?handle=#{handle}", token: token)
       .and_return(database)
     allow(Aptible::Api::Database).to receive(:find_by_url)
-      .with("/search/database?handle=#{handle}&environment=#{account.handle}", token: token)
+      .with("/find/database?handle=#{handle}&environment=#{account.handle}", token: token)
       .and_return(database)
   end
 
@@ -158,7 +158,7 @@ describe Aptible::CLI::Agent do
   describe '#db:tunnel' do
     it 'should fail if database is non-existent' do
       allow(Aptible::Api::Database).to receive(:find_by_url)
-        .with("/search/database?handle=#{handle}", token: token)
+        .with("/find/database?handle=#{handle}", token: token)
         .and_return(nil)
       expect do
         subject.send('db:tunnel', handle)
@@ -378,7 +378,7 @@ describe Aptible::CLI::Agent do
         .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
       allow(Aptible::Api::Account).to receive(:find_by_url)
-        .with("/search/account?handle=#{staging.handle}", token: token)
+        .with("/find/account?handle=#{staging.handle}", token: token)
         .and_return(staging)
       allow(Aptible::Api::ExternalAwsResource).to receive(:all)
         .with(token: token)
@@ -555,7 +555,7 @@ describe Aptible::CLI::Agent do
         .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
         .and_return([staging, prod])
       allow(Aptible::Api::Account).to receive(:find_by_url)
-        .with("/search/account?handle=#{staging.handle}", token: token)
+        .with("/find/account?handle=#{staging.handle}", token: token)
         .and_return(staging)
       allow(Aptible::Api::ExternalAwsResource).to receive(:all)
         .with(token: token)
@@ -823,7 +823,7 @@ describe Aptible::CLI::Agent do
         allow(error).to receive(:body)
           .and_return('error' => 'multiple_resources_found')
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{handle}", token: token)
+          .with("/find/database?handle=#{handle}", token: token)
           .and_raise(error)
 
         expect { subject.send('db:url', handle) }
@@ -837,10 +837,10 @@ describe Aptible::CLI::Agent do
     let(:replica) { Fabricate(:database, account: master.account, handle: 'replica') }
     before do
       allow(Aptible::Api::Database).to receive(:find_by_url)
-        .with("/search/database?handle=#{master.handle}", token: token)
+        .with("/find/database?handle=#{master.handle}", token: token)
         .and_return(master)
       allow(Aptible::Api::Database).to receive(:find_by_url)
-        .with("/search/database?handle=#{replica.handle}&environment=#{account.handle}", token: token)
+        .with("/find/database?handle=#{replica.handle}&environment=#{account.handle}", token: token)
         .and_return(replica)
     end
 
@@ -1409,7 +1409,7 @@ describe Aptible::CLI::Agent do
       allow(subject).to receive(:options)
         .and_return(environment: account.handle)
       allow(Aptible::Api::Account).to receive(:find_by_url)
-        .with("/search/account?handle=#{account.handle}", token: token)
+        .with("/find/account?handle=#{account.handle}", token: token)
         .and_return(account)
     end
     context 'with environment and db' do

--- a/spec/aptible/cli/subcommands/db_spec.rb
+++ b/spec/aptible/cli/subcommands/db_spec.rb
@@ -13,11 +13,17 @@ describe Aptible::CLI::Agent do
     allow(Aptible::Api::DatabaseCredential).to receive(:all) do
       database.database_credentials
     end
+    allow(Aptible::Api::Database).to receive(:find_by_url)
+      .with("/search/database?handle=#{handle}", token: token)
+      .and_return(database)
+    allow(Aptible::Api::Database).to receive(:find_by_url)
+      .with("/search/database?handle=#{handle}&environment=#{account.handle}", token: token)
+      .and_return(database)
   end
 
   let(:handle) { 'foobar' }
   let(:stack) { Fabricate(:stack, internal_domain: 'aptible.in') }
-  let(:account) { Fabricate(:account, stack: stack) }
+  let(:account) { Fabricate(:account, stack: stack, handle: 'aptible') }
   let(:database) { Fabricate(:database, handle: handle, account: account) }
   let(:socat_helper) { SocatHelperMock.new(port: 4242) }
 
@@ -151,15 +157,15 @@ describe Aptible::CLI::Agent do
 
   describe '#db:tunnel' do
     it 'should fail if database is non-existent' do
-      allow(Aptible::Api::Database).to receive(:all) { [] }
+      allow(Aptible::Api::Database).to receive(:find_by_url)
+        .with("/search/database?handle=#{handle}", token: token)
+        .and_return(nil)
       expect do
         subject.send('db:tunnel', handle)
       end.to raise_error("Could not find database #{handle}")
     end
 
     context 'valid database' do
-      before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
-
       it 'prints a message explaining how to connect' do
         cred = Fabricate(:database_credential, default: true, type: 'foo',
                                                database: database)
@@ -627,7 +633,6 @@ describe Aptible::CLI::Agent do
 
   describe '#db:backup' do
     before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
-    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
 
     let(:op) { Fabricate(:operation) }
 
@@ -642,6 +647,7 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('db:backup', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
@@ -649,7 +655,6 @@ describe Aptible::CLI::Agent do
 
   describe '#db:reload' do
     before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
-    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
 
     let(:op) { Fabricate(:operation) }
 
@@ -664,6 +669,7 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('db:reload', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
@@ -671,7 +677,6 @@ describe Aptible::CLI::Agent do
 
   describe '#db:restart' do
     before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
-    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
 
     let(:op) { Fabricate(:operation) }
 
@@ -736,6 +741,7 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('db:restart', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
@@ -743,7 +749,6 @@ describe Aptible::CLI::Agent do
 
   describe '#db:modify' do
     before { allow(Aptible::Api::Account).to receive(:all) { [account] } }
-    before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
 
     let(:op) { Fabricate(:operation) }
 
@@ -783,16 +788,15 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('db:modify', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
   end
 
   describe '#db:url' do
-    let(:databases) { [database] }
-    before { expect(Aptible::Api::Database).to receive(:all) { databases } }
-
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('db:url', 'nope') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
@@ -808,7 +812,12 @@ describe Aptible::CLI::Agent do
       end
 
       it 'fails if multiple DBs are found' do
-        databases << database
+        error = StandardError.new('multiple resources found')
+        allow(error).to receive(:body)
+          .and_return('error' => 'multiple_resources_found')
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{handle}", token: token)
+          .and_raise(error)
 
         expect { subject.send('db:url', handle) }
           .to raise_error(/Multiple databases/)
@@ -817,16 +826,18 @@ describe Aptible::CLI::Agent do
   end
 
   describe '#db:replicate' do
-    let(:databases) { [] }
-    before { allow(Aptible::Api::Database).to receive(:all) { databases } }
+    let(:master) { Fabricate(:database, handle: 'master') }
+    let(:replica) { Fabricate(:database, account: master.account, handle: 'replica') }
+    before do
+      allow(Aptible::Api::Database).to receive(:find_by_url)
+        .with("/search/database?handle=#{master.handle}", token: token)
+        .and_return(master)
+      allow(Aptible::Api::Database).to receive(:find_by_url)
+        .with("/search/database?handle=#{replica.handle}&environment=#{account.handle}", token: token)
+        .and_return(replica)
+    end
 
     def expect_replicate_database(opts = {})
-      master = Fabricate(:database, handle: 'master')
-      databases << master
-      replica = Fabricate(:database,
-                          account: master.account,
-                          handle: 'replica')
-
       op = Fabricate(:operation)
 
       params = { type: 'replicate', handle: 'replica' }.merge(opts)
@@ -835,7 +846,6 @@ describe Aptible::CLI::Agent do
         .with(**params).and_return(op)
 
       expect(subject).to receive(:attach_to_operation_logs).with(op) do
-        databases << replica
         replica
       end
 
@@ -867,17 +877,12 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if the DB is not found' do
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect { subject.send('db:replicate', 'nope', 'replica') }
         .to raise_error(Thor::Error, 'Could not find database nope')
     end
 
     it 'allows logical replication of a database with --version set' do
-      master = Fabricate(:database, handle: 'master')
-      databases << master
-      replica = Fabricate(:database,
-                          account: master.account,
-                          handle: 'replica')
-
       dbimg = Fabricate(:database_image,
                         type: 'postgresql',
                         version: 10,
@@ -894,7 +899,6 @@ describe Aptible::CLI::Agent do
         .with(**params).and_return(op)
 
       expect(subject).to receive(:attach_to_operation_logs).with(op) do
-        databases << replica
         replica
       end
 
@@ -914,9 +918,6 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if logical replication requested without --version' do
-      master = Fabricate(:database, handle: 'master', type: 'postgresql')
-      databases << master
-
       subject.options = { type: 'replicate', handle: 'replica', logical: true }
       expect { subject.send('db:replicate', 'master', 'replica') }
         .to raise_error(Thor::Error, '--version is required for logical ' \
@@ -924,9 +925,7 @@ describe Aptible::CLI::Agent do
     end
 
     it 'fails if logical replication requested for non-postgres db' do
-      master = Fabricate(:database, handle: 'master', type: 'mysql')
-      databases << master
-
+      master.type = 'mysql'
       subject.options = { type: 'replicate', handle: 'replica',
                           logical: true, version: 10 }
       expect { subject.send('db:replicate', 'master', 'replica') }
@@ -937,17 +936,13 @@ describe Aptible::CLI::Agent do
 
   describe '#db:dump' do
     it 'should fail if database is non-existent' do
-      allow(Aptible::Api::Database).to receive(:all) { [] }
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect do
         subject.send('db:dump', handle)
       end.to raise_error("Could not find database #{handle}")
     end
 
     context 'valid database' do
-      before do
-        allow(Aptible::Api::Database).to receive(:all) { [database] }
-      end
-
       it 'exits with the same code as pg_dump' do
         exit_status = 123
         cred = Fabricate(:database_credential, default: true, type: 'foo',
@@ -1132,7 +1127,7 @@ describe Aptible::CLI::Agent do
   describe '#db:execute' do
     sql_path = 'file.sql'
     it 'should fail if database is non-existent' do
-      allow(Aptible::Api::Database).to receive(:all) { [] }
+      allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
       expect do
         subject.send('db:execute', handle, sql_path)
       end.to raise_error("Could not find database #{handle}")
@@ -1140,7 +1135,6 @@ describe Aptible::CLI::Agent do
 
     context 'valid database' do
       before do
-        allow(Aptible::Api::Database).to receive(:all) { [database] }
         allow(subject).to receive(:`).with(/psql .*/) { `exit 0` }
       end
 
@@ -1338,8 +1332,6 @@ describe Aptible::CLI::Agent do
   end
 
   describe '#db:deprovision' do
-    before { expect(Aptible::Api::Database).to receive(:all) { [database] } }
-
     let(:operation) { Fabricate(:operation, resource: database) }
 
     it 'deprovisions a database' do
@@ -1422,6 +1414,7 @@ describe Aptible::CLI::Agent do
         )
       end
       it 'should fail if db does not exist' do
+        allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
         expect { subject.send('db:rename', 'foo2', 'foo3') }
           .to raise_error(/Could not find database foo2/)
       end

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -4,7 +4,7 @@ describe Aptible::CLI::Agent do
   let!(:account) { Fabricate(:account, handle: 'foobar') }
   let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
   let(:operation) { Fabricate(:operation) }
-  let(:token) { double'token' }
+  let(:token) { double 'token' }
 
   describe '#deploy' do
     before do

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -12,7 +12,9 @@ describe Aptible::CLI::Agent do
         .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
         .and_return(app)
       allow(subject).to receive(:fetch_token) { token }
-      allow(Aptible::Api::Account).to receive(:all) { [account] }
+      allow(Aptible::Api::Account).to receive(:find_by_url)
+        .with("/search/account?handle=#{account.handle}", token: token)
+        .and_return(account)
     end
 
     context 'with app' do

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -4,12 +4,15 @@ describe Aptible::CLI::Agent do
   let!(:account) { Fabricate(:account, handle: 'foobar') }
   let!(:app) { Fabricate(:app, handle: 'hello', account: account) }
   let(:operation) { Fabricate(:operation) }
+  let(:token) { double'token' }
 
   describe '#deploy' do
     before do
-      allow(Aptible::Api::App).to receive(:all) { [app] }
+      allow(Aptible::Api::App).to receive(:find_by_url)
+        .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
+        .and_return(app)
+      allow(subject).to receive(:fetch_token) { token }
       allow(Aptible::Api::Account).to receive(:all) { [account] }
-      allow(subject).to receive(:fetch_token) { double'token' }
     end
 
     context 'with app' do

--- a/spec/aptible/cli/subcommands/deploy_spec.rb
+++ b/spec/aptible/cli/subcommands/deploy_spec.rb
@@ -9,11 +9,11 @@ describe Aptible::CLI::Agent do
   describe '#deploy' do
     before do
       allow(Aptible::Api::App).to receive(:find_by_url)
-        .with("/search/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
+        .with("/find/app?handle=#{app.handle}&environment=#{account.handle}", token: token)
         .and_return(app)
       allow(subject).to receive(:fetch_token) { token }
       allow(Aptible::Api::Account).to receive(:find_by_url)
-        .with("/search/account?handle=#{account.handle}", token: token)
+        .with("/find/account?handle=#{account.handle}", token: token)
         .and_return(account)
     end
 

--- a/spec/aptible/cli/subcommands/endpoints_spec.rb
+++ b/spec/aptible/cli/subcommands/endpoints_spec.rb
@@ -12,6 +12,9 @@ describe Aptible::CLI::Agent do
       .to receive(:all)
       .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([a1, a2])
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{a2.handle}", token: token)
+      .and_return(a2)
   end
 
   def expect_create_certificate(account, options)

--- a/spec/aptible/cli/subcommands/endpoints_spec.rb
+++ b/spec/aptible/cli/subcommands/endpoints_spec.rb
@@ -13,7 +13,7 @@ describe Aptible::CLI::Agent do
       .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([a1, a2])
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{a2.handle}", token: token)
+      .with("/find/account?handle=#{a2.handle}", token: token)
       .and_return(a2)
   end
 
@@ -71,10 +71,10 @@ describe Aptible::CLI::Agent do
 
     before do
       allow(Aptible::Api::Database).to receive(:find_by_url)
-        .with("/search/database?handle=#{incomplete.handle}", token: token)
+        .with("/find/database?handle=#{incomplete.handle}", token: token)
         .and_return(incomplete)
       allow(Aptible::Api::Database).to receive(:find_by_url)
-        .with("/search/database?handle=#{db.handle}", token: token)
+        .with("/find/database?handle=#{db.handle}", token: token)
         .and_return(db)
       allow(db).to receive(:class).and_return(Aptible::Api::Database)
       allow(incomplete).to receive(:class).and_return(Aptible::Api::Database)
@@ -97,7 +97,7 @@ describe Aptible::CLI::Agent do
       it 'fails if the DB is not in the account' do
         stub_options(environment: 'bar')
         expect(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{db.handle}&environment=bar", token: token)
+          .with("/find/database?handle=#{db.handle}&environment=bar", token: token)
           .and_return(nil)
         expect { subject.send('endpoints:database:create', 'mydb') }
           .to raise_error(/could not find database mydb/im)
@@ -236,7 +236,7 @@ describe Aptible::CLI::Agent do
       allow(Aptible::Api::App).to receive(:find_by_url)
         .and_return(nil)
       allow(Aptible::Api::App).to receive(:find_by_url)
-        .with("/search/app?handle=#{app.handle}", token: token)
+        .with("/find/app?handle=#{app.handle}", token: token)
         .and_return(app)
 
       allow(app).to receive(:class).and_return(Aptible::Api::App)

--- a/spec/aptible/cli/subcommands/endpoints_spec.rb
+++ b/spec/aptible/cli/subcommands/endpoints_spec.rb
@@ -67,10 +67,12 @@ describe Aptible::CLI::Agent do
     end
 
     before do
-      allow(Aptible::Api::Database)
-        .to receive(:all)
-        .with(token: token, href: '/databases?per_page=5000&no_embed=true')
-        .and_return([db, incomplete])
+      allow(Aptible::Api::Database).to receive(:find_by_url)
+        .with("/search/database?handle=#{incomplete.handle}", token: token)
+        .and_return(incomplete)
+      allow(Aptible::Api::Database).to receive(:find_by_url)
+        .with("/search/database?handle=#{db.handle}", token: token)
+        .and_return(db)
       allow(db).to receive(:class).and_return(Aptible::Api::Database)
       allow(incomplete).to receive(:class).and_return(Aptible::Api::Database)
       stub_options
@@ -78,6 +80,7 @@ describe Aptible::CLI::Agent do
 
     describe 'endpoints:database:create' do
       it 'fails if the DB does not exist' do
+        allow(Aptible::Api::Database).to receive(:find_by_url).and_return(nil)
         expect { subject.send('endpoints:database:create', 'some') }
           .to raise_error(/could not find database some/im)
       end
@@ -90,6 +93,9 @@ describe Aptible::CLI::Agent do
 
       it 'fails if the DB is not in the account' do
         stub_options(environment: 'bar')
+        expect(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{db.handle}&environment=bar", token: token)
+          .and_return(nil)
         expect { subject.send('endpoints:database:create', 'mydb') }
           .to raise_error(/could not find database mydb/im)
       end

--- a/spec/aptible/cli/subcommands/endpoints_spec.rb
+++ b/spec/aptible/cli/subcommands/endpoints_spec.rb
@@ -223,6 +223,13 @@ describe Aptible::CLI::Agent do
         .to receive(:all)
         .with(token: token, href: '/apps?per_page=5000&no_embed=true')
         .and_return([app])
+
+      allow(Aptible::Api::App).to receive(:find_by_url)
+        .and_return(nil)
+      allow(Aptible::Api::App).to receive(:find_by_url)
+        .with("/search/app?handle=#{app.handle}", token: token)
+        .and_return(app)
+
       allow(app).to receive(:class).and_return(Aptible::Api::App)
       stub_options
     end

--- a/spec/aptible/cli/subcommands/environment_spec.rb
+++ b/spec/aptible/cli/subcommands/environment_spec.rb
@@ -16,6 +16,9 @@ describe Aptible::CLI::Agent do
       .to receive(:all)
       .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([a1, a2])
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{a1.handle}", token: token)
+      .and_return(a1)
   end
 
   describe('#environment:list') do
@@ -123,6 +126,7 @@ describe Aptible::CLI::Agent do
       )
     end
     it 'should fail if env does not exist' do
+      allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil)
       expect { subject.send('environment:rename', 'foo1', 'foo2') }
         .to raise_error(/Could not find environment foo1/)
     end

--- a/spec/aptible/cli/subcommands/environment_spec.rb
+++ b/spec/aptible/cli/subcommands/environment_spec.rb
@@ -17,7 +17,7 @@ describe Aptible::CLI::Agent do
       .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([a1, a2])
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{a1.handle}", token: token)
+      .with("/find/account?handle=#{a1.handle}", token: token)
       .and_return(a1)
   end
 

--- a/spec/aptible/cli/subcommands/log_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/log_drain_spec.rb
@@ -23,7 +23,7 @@ describe Aptible::CLI::Agent do
       .and_return([account])
 
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{account.handle}", token: token)
+      .with("/find/account?handle=#{account.handle}", token: token)
       .and_return(account)
 
     allow(account).to receive(:reload).and_return(account)
@@ -93,7 +93,7 @@ describe Aptible::CLI::Agent do
       let(:db) { Fabricate(:database, account: account, id: 5) }
       before do
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{db.handle}&environment=#{db.account.handle}", token: token)
+          .with("/find/database?handle=#{db.handle}&environment=#{db.account.handle}", token: token)
           .and_return(db)
       end
 

--- a/spec/aptible/cli/subcommands/log_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/log_drain_spec.rb
@@ -22,6 +22,10 @@ describe Aptible::CLI::Agent do
       .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([account])
 
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{account.handle}", token: token)
+      .and_return(account)
+
     allow(account).to receive(:reload).and_return(account)
   end
 

--- a/spec/aptible/cli/subcommands/log_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/log_drain_spec.rb
@@ -87,6 +87,11 @@ describe Aptible::CLI::Agent do
 
     context 'elasticsearch' do
       let(:db) { Fabricate(:database, account: account, id: 5) }
+      before do
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{db.handle}&environment=#{db.account.handle}", token: token)
+          .and_return(db)
+      end
 
       it 'creates a new Elasticsearch log drain' do
         opts = {

--- a/spec/aptible/cli/subcommands/logs_spec.rb
+++ b/spec/aptible/cli/subcommands/logs_spec.rb
@@ -4,9 +4,10 @@ describe Aptible::CLI::Agent do
   before do
     allow(subject).to receive(:ask)
     allow(subject).to receive(:save_token)
-    allow(subject).to receive(:fetch_token) { 'some token' }
+    allow(subject).to receive(:fetch_token) { token }
   end
 
+  let(:token) { 'some token' }
   let(:app) { Fabricate(:app, handle: 'foo') }
   let(:database) { Fabricate(:database, handle: 'bar', status: 'provisioned') }
   let(:service) { Fabricate(:service, app: app) }
@@ -39,7 +40,14 @@ describe Aptible::CLI::Agent do
     end
 
     context 'Database resource' do
-      before { allow(Aptible::Api::Database).to receive(:all) { [database] } }
+      before do
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{database.handle}&environment=#{database.account.handle}", token: token)
+          .and_return(database)
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{database.handle}", token: token)
+          .and_return(database)
+      end
       before { subject.options = { database: database.handle } }
 
       it 'should fail if the database is unprovisioned' do

--- a/spec/aptible/cli/subcommands/logs_spec.rb
+++ b/spec/aptible/cli/subcommands/logs_spec.rb
@@ -12,10 +12,14 @@ describe Aptible::CLI::Agent do
   let(:service) { Fabricate(:service, app: app) }
 
   describe '#logs' do
-    before { allow(Aptible::Api::Account).to receive(:all) { [app.account] } }
+    before do
+      allow(Aptible::Api::Account).to receive(:all) { [app.account] }
+      allow(Aptible::Api::App).to receive(:find_by_url)
+        .with("/search/app?handle=#{app.handle}", token: 'some token')
+        .and_return(app)
+    end
 
     context 'App resource' do
-      before { allow(Aptible::Api::App).to receive(:all) { [app] } }
       before { subject.options = { app: app.handle } }
 
       it 'should fail if the app is unprovisioned' do

--- a/spec/aptible/cli/subcommands/logs_spec.rb
+++ b/spec/aptible/cli/subcommands/logs_spec.rb
@@ -16,7 +16,7 @@ describe Aptible::CLI::Agent do
     before do
       allow(Aptible::Api::Account).to receive(:all) { [app.account] }
       allow(Aptible::Api::App).to receive(:find_by_url)
-        .with("/search/app?handle=#{app.handle}", token: 'some token')
+        .with("/find/app?handle=#{app.handle}", token: 'some token')
         .and_return(app)
     end
 
@@ -42,10 +42,10 @@ describe Aptible::CLI::Agent do
     context 'Database resource' do
       before do
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{database.handle}&environment=#{database.account.handle}", token: token)
+          .with("/find/database?handle=#{database.handle}&environment=#{database.account.handle}", token: token)
           .and_return(database)
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{database.handle}", token: token)
+          .with("/find/database?handle=#{database.handle}", token: token)
           .and_return(database)
       end
       before { subject.options = { database: database.handle } }

--- a/spec/aptible/cli/subcommands/maintenance_spec.rb
+++ b/spec/aptible/cli/subcommands/maintenance_spec.rb
@@ -9,6 +9,9 @@ describe Aptible::CLI::Agent do
     allow(subject).to receive(:ask)
     allow(subject).to receive(:save_token)
     allow(subject).to receive(:fetch_token) { token }
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{staging.handle}", token: token)
+      .and_return(staging)
   end
 
   let(:handle) { 'foobar' }
@@ -52,7 +55,6 @@ describe Aptible::CLI::Agent do
 
   describe '#maintenance:dbs' do
     before do
-      token = 'the-token'
       allow(subject).to receive(:fetch_token) { token }
       allow(Aptible::Api::Account).to receive(:all)
         .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
@@ -112,6 +114,8 @@ describe Aptible::CLI::Agent do
     end
 
     context 'when an invalid account is specified' do
+      before { allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil) }
+
       it 'prints out an error' do
         subject.options = { environment: 'foo' }
         expect { subject.send('maintenance:dbs') }
@@ -121,7 +125,6 @@ describe Aptible::CLI::Agent do
   end
   describe '#maintenance:apps' do
     before do
-      token = 'the-token'
       allow(subject).to receive(:fetch_token) { token }
       allow(Aptible::Api::Account).to receive(:all)
         .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
@@ -180,7 +183,10 @@ describe Aptible::CLI::Agent do
     end
 
     context 'when an invalid account is specified' do
+      before { allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil) }
+
       it 'prints out an error' do
+        allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil)
         subject.options = { environment: 'foo' }
         expect { subject.send('maintenance:apps') }
           .to raise_error('Specified account does not exist')

--- a/spec/aptible/cli/subcommands/maintenance_spec.rb
+++ b/spec/aptible/cli/subcommands/maintenance_spec.rb
@@ -10,7 +10,7 @@ describe Aptible::CLI::Agent do
     allow(subject).to receive(:save_token)
     allow(subject).to receive(:fetch_token) { token }
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{staging.handle}", token: token)
+      .with("/find/account?handle=#{staging.handle}", token: token)
       .and_return(staging)
   end
 

--- a/spec/aptible/cli/subcommands/maintenance_spec.rb
+++ b/spec/aptible/cli/subcommands/maintenance_spec.rb
@@ -186,7 +186,6 @@ describe Aptible::CLI::Agent do
       before { allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil) }
 
       it 'prints out an error' do
-        allow(Aptible::Api::Account).to receive(:find_by_url).and_return(nil)
         subject.options = { environment: 'foo' }
         expect { subject.send('maintenance:apps') }
           .to raise_error('Specified account does not exist')

--- a/spec/aptible/cli/subcommands/metric_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/metric_drain_spec.rb
@@ -23,7 +23,7 @@ describe Aptible::CLI::Agent do
       .and_return([account])
 
     allow(Aptible::Api::Account).to receive(:find_by_url)
-      .with("/search/account?handle=#{account.handle}", token: token)
+      .with("/find/account?handle=#{account.handle}", token: token)
       .and_return(account)
   end
 
@@ -90,7 +90,7 @@ describe Aptible::CLI::Agent do
 
       before do
         allow(Aptible::Api::Database).to receive(:find_by_url)
-          .with("/search/database?handle=#{db.handle}&environment=#{db.account.handle}", token: token)
+          .with("/find/database?handle=#{db.handle}&environment=#{db.account.handle}", token: token)
           .and_return(db)
       end
 

--- a/spec/aptible/cli/subcommands/metric_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/metric_drain_spec.rb
@@ -86,6 +86,12 @@ describe Aptible::CLI::Agent do
     context 'influxdb' do
       let(:db) { Fabricate(:database, account: account, id: 5) }
 
+      before do
+        allow(Aptible::Api::Database).to receive(:find_by_url)
+          .with("/search/database?handle=#{db.handle}&environment=#{db.account.handle}", token: token)
+          .and_return(db)
+      end
+
       it 'creates a new InfluxDB metric drain' do
         opts = {
           handle: 'test-influxdb',

--- a/spec/aptible/cli/subcommands/metric_drain_spec.rb
+++ b/spec/aptible/cli/subcommands/metric_drain_spec.rb
@@ -21,6 +21,10 @@ describe Aptible::CLI::Agent do
     allow(Aptible::Api::Account).to receive(:all)
       .with(token: token, href: '/accounts?per_page=5000&no_embed=true')
       .and_return([account])
+
+    allow(Aptible::Api::Account).to receive(:find_by_url)
+      .with("/search/account?handle=#{account.handle}", token: token)
+      .and_return(account)
   end
 
   describe '#metric_drain:list' do
@@ -57,8 +61,6 @@ describe Aptible::CLI::Agent do
     it 'lists metric drains for a single account with --environment' do
       other_account = Fabricate(:account)
       Fabricate(:metric_drain, handle: 'test2', account: other_account)
-      accounts = [account, other_account]
-      allow(Aptible::Api::Account).to receive(:all).and_return(accounts)
 
       subject.options = { environment: account.handle }
       subject.send('metric_drain:list')

--- a/spec/aptible/cli/subcommands/services_spec.rb
+++ b/spec/aptible/cli/subcommands/services_spec.rb
@@ -6,10 +6,9 @@ describe Aptible::CLI::Agent do
 
   before do
     allow(subject).to receive(:fetch_token) { token }
-    allow(Aptible::Api::App)
-      .to receive(:all)
-      .with(token: token, href: '/apps?per_page=5000&no_embed=true')
-      .and_return([app])
+    allow(Aptible::Api::App).to receive(:find_by_url)
+      .with("/search/app?handle=#{app.handle}", token: token)
+      .and_return(app)
   end
 
   describe '#services' do

--- a/spec/aptible/cli/subcommands/services_spec.rb
+++ b/spec/aptible/cli/subcommands/services_spec.rb
@@ -7,7 +7,7 @@ describe Aptible::CLI::Agent do
   before do
     allow(subject).to receive(:fetch_token) { token }
     allow(Aptible::Api::App).to receive(:find_by_url)
-      .with("/search/app?handle=#{app.handle}", token: token)
+      .with("/find/app?handle=#{app.handle}", token: token)
       .and_return(app)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,6 +81,8 @@ module SpecHarness
 end
 
 RSpec.configure do |config|
+  config.example_status_persistence_file_path = 'spec/reports/examples.txt'
+
   config.before(:each) do
     reset_spec_harness
     begin


### PR DESCRIPTION
We have an API endpoint that allows returning apps and databases for a given handle, or for a a combination of handle and account handle. This is much faster than doing the filtering client side.

Tho illustrates the time it takes to identify an app by handle, I ran `aptible config --app httpd` in a test account with 400 apps. The performance of the current CLI release is as follows: (real CLI execution time and the response time of the request we're changing)

> real 5.016s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.78s
> real 5.484s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 4.41s
> real 5.218s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 4.18s
> real 4.900s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.86s
> real 4.860s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.82s
> real 4.778s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.74s
> real 4.786s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.76s
> real 4.806s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.8s
> real 4.508s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 3.51s
> real 5.514s => GET https://api.aptible.com/apps?per_page=5000&no_embed=true (0) 4.46s

Versus this PR:

> real 1.267s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.28s
> real 1.248s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.27s
> real 1.257s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.28s
> real 1.309s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.32s
> real 1.255s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.27s
> real 1.225s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.27s
> real 1.350s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.29s
> real 1.273s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.29s
> real 1.261s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.29s
> real 1.289s => GET https://api.aptible.com/find/app?handle=httpd (0) 0.3s

The same change has been made to databases, as well as accounts.