### PR TITLE
Fix sensitive access for users without permission

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aptible-cli (0.26.7)
+    aptible-cli (0.26.8)
       activesupport (>= 4.0, < 6.0)
       aptible-api (~> 1.12)
       aptible-auth (~> 1.4)

--- a/lib/aptible/cli/resource_formatter.rb
+++ b/lib/aptible/cli/resource_formatter.rb
@@ -125,10 +125,12 @@ module Aptible
           unless setting.nil?
             node.value('docker_image',
                        setting.settings['APTIBLE_DOCKER_IMAGE'])
-            node.value('private_registry_username',
-                       setting.sensitive_settings['APTIBLE_PRIVATE_REGISTRY_USERNAME'])
-            node.value('private_registry_password',
-                       setting.sensitive_settings['APTIBLE_PRIVATE_REGISTRY_PASSWORD'])
+            if setting.sensitive_settings.is_a?(Hash)
+              node.value('private_registry_username',
+                         setting.sensitive_settings['APTIBLE_PRIVATE_REGISTRY_USERNAME'])
+              node.value('private_registry_password',
+                         setting.sensitive_settings['APTIBLE_PRIVATE_REGISTRY_PASSWORD'])
+            end
           end
         end
 

--- a/lib/aptible/cli/version.rb
+++ b/lib/aptible/cli/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module CLI
-    VERSION = '0.26.7'.freeze
+    VERSION = '0.26.8'.freeze
   end
 end


### PR DESCRIPTION
Allows users without sensitive access to sucessfully JSON output `aptible apps`: they just dont see these fields in the output at all, rather than returning null or "no permission".